### PR TITLE
Change domain in ingress

### DIFF
--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -31,6 +31,6 @@ env:
 # Spec ingress policy for the `api` and `metrics` port.
 # Values are a list of NetworkPolicyPeer v1 objects, empty means allow all.
 ingress:
-  host: "crypto.stage-crypto.worldcoin.dev"
+  host: "signup.stage-crypto.worldcoin.dev"
   api:
   metrics:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

"crypto" subdomain wasn't the best. We're routing based on domains not paths thus updating to:
`signup.stage-crypto.worldcoin.dev`, other services will be available at `hubble.stage-crypto.worldcoin.dev` and `mint.stage-crypto.worldcoin.dev`

## Solution

Updating ingress
