### PR TITLE
Add env var for mocking eth connection

### DIFF
--- a/src/ethereum/mod.rs
+++ b/src/ethereum/mod.rs
@@ -39,7 +39,12 @@ pub struct Options {
     #[structopt(short, parse(try_from_str), default_value = "true")]
     pub eip1559: bool,
 
-    #[structopt(short, parse(try_from_str), default_value = "false")]
+    #[structopt(
+        short,
+        parse(try_from_str),
+        default_value = "false",
+        env = "SIGNUP_SEQUENCER_MOCK"
+    )]
     pub mock: bool,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Mock mode can be activated either via CLI param `-m true` or now an env var `SIGNUP_SEQUENCER_MOCK`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
