### PR TITLE
B-522 feat(traefik): Add CORS configuration as Traefik middleware

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -296,6 +296,7 @@ jobs:
           --set image.pullSecret=ghcr-secret
           --set env.ETHEREUM_PROVIDER="${{ secrets.ALCHEMY_GOERLI_RPC_ENDPOINT }}"
           --set persistentStorage.enabled=false
+          --set ingress.cors.enabled=false
       - name: Describe pods
         if: always()
         run: kubectl describe pod

--- a/deploy/templates/cors.yaml
+++ b/deploy/templates/cors.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.cors.enabled }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
@@ -13,3 +14,4 @@ spec:
       - "*"
     accessControlMaxAge: 100
     addVaryHeader: true
+{{- end }}

--- a/deploy/templates/cors.yaml
+++ b/deploy/templates/cors.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: cors
+  namespace: signup-sequencer
+spec:
+  headers:
+    accessControlAllowMethods:
+      - "GET"
+      - "OPTIONS"
+      - "PUT"
+    accessControlAllowOriginList:
+      - "*"
+    accessControlMaxAge: 100
+    addVaryHeader: true

--- a/deploy/templates/ingress.yaml
+++ b/deploy/templates/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     ingress.kubernetes.io/protocol: http
     traefik.frontend.rule.type: PathPrefix
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.middlewares: signup-sequencer-cors@kubernetescrd
 spec:
   rules:
     - host: {{ .Values.ingress.host }}

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -35,6 +35,8 @@ ingress:
   host: "signup.crypto.worldcoin.dev"
   api:
   metrics:
+  cors: # Enable Traefik Middleware with CORS headers
+    enabled: true
 
 persistentStorage:
   enabled: true


### PR DESCRIPTION
## Motivation

I've got a request to configure CORS for the API.

## Solution

I use Traefik middleware to inject cors headers. The solution was tested on stage:
```
curl -i --location --request POST 'https://signup.stage-crypto.worldcoin.dev/insertIdentity' \
      --header 'Content-Type: application/json' \
      --data-raw '[0, "0x0000000000000000000000000000000000000000000000000000000000000000"]'
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *

curl -i --location --request OPTION https://signup.stage-crypto.worldcoin.dev/
HTTP/1.1 500 Internal Server Error
Access-Control-Allow-Origin: *
```
The OPTIONS request on root context should return an empty body 204 response instead of 500. I think this should be handled on the application level.

https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
