### PR TITLE
Add Crypto Team to CD codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 .github @remco @worldcoin/crypto
 
 # CD
-.github/workflows/cd.yml @recmo @kkowalski @worldcoin/infrastructure
-deploy/ @recmo @kkowalski  @worldcoin/infrastructure
+.github/workflows/cd.yml @worldcoin/infrastructure @worldcoin/crypto
+deploy/ @worldcoin/infrastructure @worldcoin/crypto


### PR DESCRIPTION
## Motivation

The Crypto Team should also be able to merge changes in CD workflow.

## Solution

Add the team to CODEOWNERS

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
