### PR TITLE
Add content-type to allowed cors headers

### DIFF
--- a/deploy/templates/cors.yaml
+++ b/deploy/templates/cors.yaml
@@ -9,9 +9,11 @@ spec:
     accessControlAllowMethods:
       - "GET"
       - "OPTIONS"
-      - "PUT"
+      - "POST"
     accessControlAllowOriginList:
       - "*"
+    accessControlAllowHeaders:
+      - "content-type"
     accessControlMaxAge: 100
     addVaryHeader: true
 {{- end }}


### PR DESCRIPTION
## Motivation

we can’t do the parsing correctly in the frontend
if you try to do a request from the browser,
```
Access to fetch at 'https://signup.stage-crypto.worldcoin.dev/insertIdentity' from origin 'http://localhost:54702/' has been blocked by CORS policy: Request header field content-type is not allowed by Access-Control-Allow-Headers in preflight response.
```

## Solution
We add `content-type` for Access-Control-Allow-Headers list

Checked on stage:
![Screenshot 2022-04-21 at 13 43 18](https://user-images.githubusercontent.com/2135758/164451044-45f7a5f6-9d6a-4e91-94cb-ef725ec96f96.png)


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
