### PR TITLE
Fix race condition in `insert_identity`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -137,6 +137,10 @@ impl App {
         group_id: usize,
         commitment: &Hash,
     ) -> Result<IndexResponse, ServerError> {
+        // TODO: improve, this is misusing the mutex on the tree as a mutex on the whole
+        // function
+        let mut merkle_tree = self.merkle_tree.write().await;
+
         // Send Semaphore transaction
         self.ethereum
             .insert_identity(group_id, commitment, self.tree_depth)
@@ -145,7 +149,6 @@ impl App {
         // Update merkle tree
         let identity_index;
         {
-            let mut merkle_tree = self.merkle_tree.write().await;
             identity_index = self.next_leaf.fetch_add(1, Ordering::AcqRel);
             merkle_tree.set(identity_index, *commitment);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

There is a race condition when multiple tree insertions happen at the same time due to waiting on the transaction to be mined.

## Solution

Hot fix in this PR: 
- Add mutex for the whole scope of the function. However, this will now block insertions until the transaction is mined.
- We can't reuse the mutex on the whole tree (`self.merkle_tree.write().await`), because this also blocks read queries in the api for the inclusion proof. 

**TODO:** Remove the transaction waiting from the mutex, so we can submit and wait for multiple tx in parallel.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
