### PR TITLE
disable eip1559 on mainnet

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -412,3 +412,4 @@ jobs:
           --set env.SIGNING_KEY="${{ secrets.MAINNET_ACCOUNT_PRIVATE_KEY }}"
           --set env.SEMAPHORE_ADDRESS="${{ secrets.MAINNET_SEMAPHORE_CONTRACT_ADDRESS }}"
           --set env.SIGNUP_SEQUENCER_MOCK=false
+          --set env.USE_EIP1559=false

--- a/src/ethereum/mod.rs
+++ b/src/ethereum/mod.rs
@@ -37,7 +37,7 @@ pub struct Options {
 
     /// If this module is being run with EIP-1559 support, useful in some places
     /// where EIP-1559 is not yet supported
-    #[structopt(short, parse(try_from_str), default_value = "true")]
+    #[structopt(short, parse(try_from_str), default_value = "true", env = "USE_EIP1559")]
     pub eip1559: bool,
 
     #[structopt(

--- a/src/ethereum/mod.rs
+++ b/src/ethereum/mod.rs
@@ -37,7 +37,12 @@ pub struct Options {
 
     /// If this module is being run with EIP-1559 support, useful in some places
     /// where EIP-1559 is not yet supported
-    #[structopt(short, parse(try_from_str), default_value = "true", env = "USE_EIP1559")]
+    #[structopt(
+        short,
+        parse(try_from_str),
+        default_value = "true",
+        env = "USE_EIP1559"
+    )]
     pub eip1559: bool,
 
     #[structopt(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Submitting a transaction to polygon mainnet currently fails with `transaction underpriced`. This is because `max_fee_per_gas` is set in correctly, such that `max_fee_per_gas` -  `max_priority_fee_per_gas` < `base_fee`. 
Geth will [reject such transactions instantly](https://github.com/ethereum/go-ethereum/issues/24079).

This migth be bug in ether-rs failing to parse the current basefee returned from the rpc, but needs futher investigation. 
Switching legacy fixes it for now.

On mumbai this does not occur because there is no min fee enforced, Polygon mainnet enforces >=30gwei min basefee fee for spam protection.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
