### PR TITLE
feat(cors): Add authorization header to allow list

### DIFF
--- a/deploy/templates/cors.yaml
+++ b/deploy/templates/cors.yaml
@@ -14,6 +14,7 @@ spec:
       - "*"
     accessControlAllowHeaders:
       - "content-type"
+      - "authorization"
     accessControlMaxAge: 100
     addVaryHeader: true
 {{- end }}


### PR DESCRIPTION
## Motivation

Getting a CORS error in the identity faucet (Access-Control-Allow-Headers on insertIdentity doesn’t include the Authorization header).

![image](https://user-images.githubusercontent.com/2135758/168076596-05d22dfe-e21a-4785-a830-aebdb8e637f9.png)


## Solution

The PR adds required header to Access-Control-Allow-Headers list.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
