### PR TITLE
sync events with block range

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -316,6 +316,8 @@ jobs:
           --set env.SIGNUP_SEQUENCER_MOCK=false
           --set env.WIPE_STORAGE=true
           --set persistentStorage.volumeID=aws://us-east-1a/vol-0b4f10016a30379d7
+          --set env.BLOCK_QUERY_RANGE=1000000
+          --set env.STARTING_BLOCK=0      
 
   deploy-stage-manual:
     name: Manual deploy to staging
@@ -352,6 +354,8 @@ jobs:
           --set env.SIGNUP_SEQUENCER_MOCK=false
           --set env.WIPE_STORAGE=true
           --set persistentStorage.volumeID=aws://us-east-1a/vol-0b4f10016a30379d7
+          --set env.BLOCK_QUERY_RANGE=1000000
+          --set env.STARTING_BLOCK=0
 
   deploy-prod:
     name: Deploy main to production
@@ -387,3 +391,5 @@ jobs:
           --set env.SIGNUP_SEQUENCER_MOCK=false
           --set env.WIPE_STORAGE=true
           --set env.USE_EIP1559=false
+          --set env.BLOCK_QUERY_RANGE=100000
+          --set env.STARTING_BLOCK=27829300


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

While syncing, we are exceeding the data limit of events:
```
Error: 
   0: (code: -32602, message: Log response size exceeded. You can make eth_getLogs requests with up to a 2K block range and no limit on the response size, or you can request any block range with a cap of 10K logs in the response. Based on your parameters and the response size limit, this block range should work: [0x0, 0x1afef94], data: None)

Location:
   /src/src/ethereum/mod.rs:165
```

## Solution

Iterate over block ranges.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
