### PR TITLE
fix: rename container name to fit datadog and prometheus instance configuration [B-696]

### DIFF
--- a/deploy/templates/statefulset.yaml
+++ b/deploy/templates/statefulset.yaml
@@ -18,9 +18,6 @@ spec:
         app: {{ include "mychart.fullname" . }}
         {{- include "mychart.labels" . | nindent 8 }}
       annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9998"
-        prometheus.io/path: "/metrics"
         ad.datadoghq.com/{{ .Chart.Name }}.check_names: |
           ["openmetrics"]
         ad.datadoghq.com/{{ .Chart.Name }}.init_configs: |
@@ -49,7 +46,7 @@ spec:
       securityContext:
         fsGroup: 10001
       containers:
-        - name: app
+        - name: {{ .Chart.Name }}
           image: "{{ .Values.image.image }}:{{ .Values.image.tag | default (print "v" .Chart.AppVersion)}}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           {{- if .Values.persistentStorage.enabled }}


### PR DESCRIPTION
Container name should match with `ad.datadoghq.com/` annotations to work properly.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
