### PR TITLE
fix: choosed previous version of snyk

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -256,6 +256,8 @@ jobs:
     steps:
       - name: Set up Snyk
         uses: snyk/actions/setup@master
+        with:
+          version: v1.1035.0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Set up Snyk
         uses: snyk/actions/setup@master
         with:
-          version: v1.1035.0
+          snyk-version: v1.1035.0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
We have to choose the previous version of snyk because the latest release doesn't contain binary files.