### PR TITLE
Update deprecated deployment label

### DIFF
--- a/deploy/templates/statefulset.yaml
+++ b/deploy/templates/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
         - name: {{ . }}
       {{ end -}}
       nodeSelector:
-        beta.kubernetes.io/arch: {{ .Values.image.arch }}
+        kubernetes.io/arch: {{ .Values.image.arch }}
       securityContext:
         fsGroup: 10001
       containers:


### PR DESCRIPTION
## Motivation
```
Warning: spec.template.spec.nodeSelector[beta.kubernetes.io/arch]: deprecated since v1.14; use "kubernetes.io/arch" instead
```
## Solution

This label has been deprecated. Use kubernetes.io/arch instead.


## PR Checklist

- [ ] Added Tests - N/A
- [ ] Added Documentation - N/A
- [ ] Updated the changelog - I cannot find it :/

