### PR TITLE
Provide OpenAPI specs and differentiate response codes in inclusionProof

### DIFF
--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   version: '1.0.0'
-  title: 'semaphore-sequencer'
+  title: 'signup-sequencer'
   license:
     name: MIT
 servers:
@@ -17,24 +17,95 @@ paths:
           description: 'Sample response: Details about a user by ID'
           content:
             'application/text':
-                example: ""
+              example: ''
         default:
           description: Unexpected error
+  /insertIdentity:
+    post:
+      summary: 'Queues an insertion of a new identity into the merkle tree'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IdentityCommitmentWithGroup'
+      responses:
+        '200':
+          description: 'Identity insert was successfully queued'
+          content:
+            application/json:
+              schema:
+                type: 'null'
+        '400':
+          description: 'Invalid request'
+          content:
+            application/json:
+              schema:
+                description: 'A human-readable explanation of the error condition'
+                type: 'string'
   /inclusionProof:
     post:
       summary: 'Get Merkle inclusion proof'
       requestBody:
-        description: user to add to the system
+        description: 'details of the identity to get the inclusion proof for'
         content:
           'application/json':
-            example:
-              groupId: 1
-              identityCommitment: '0x29e6e65081384cf703af5ef3e9708deeb3d7b3c42b6da709d3335b19d224bdce'
+            schema:
+              $ref: '#/components/schemas/IdentityCommitmentWithGroup'
       responses:
         '200':
-          description: 'Sample response: Details about a user by ID'
+          description: 'A Merkle inclusion proof for an already inserted commitment'
           content:
             'application/json':
-                example: ""
-        default:
-          description: Unexpected error
+              schema:
+                $ref: '#/components/schemas/InclusionProof'
+        '202':
+          description: 'The commitment has been queued but it is not yet included in the tree'
+          content:
+            'application/json':
+              schema:
+                type: string
+                enum: [ 'pending' ]
+        '400':
+          description: 'Invalid request'
+          content:
+            application/json:
+              schema:
+                description: 'A human-readable explanation of the error condition'
+                type: 'string'
+components:
+  schemas:
+    IdentityCommitment:
+      type: string
+      pattern: '^[A-F0-9]{64}$'
+    IdentityCommitmentWithGroup:
+      type: object
+      properties:
+        groupId:
+          type: integer
+          format: int64
+        identityCommitment:
+          $ref: '#/components/schemas/IdentityCommitment'
+      example:
+        groupId: 1
+        identityCommitment: '0000F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2F2'
+    FieldElement:
+      type: string
+      pattern: '^0x[a-f0-9]{64}$'
+    InclusionProof:
+      type: object
+      properties:
+        proof:
+          type: object
+          properties:
+            root: { $ref: '#/components/schemas/FieldElement' }
+            proof:
+              type: array
+              items:
+                oneOf:
+                  - type: object
+                    properties:
+                      Left: { $ref: '#/components/schemas/FieldElement' }
+                  - type: object
+                    properties:
+                      Right: { $ref: '#/components/schemas/FieldElement' }

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,8 +49,8 @@ pub enum InclusionProofResponse {
 impl ToResponseCode for InclusionProofResponse {
     fn to_response_code(&self) -> StatusCode {
         match self {
-            InclusionProofResponse::Proof { .. } => StatusCode::OK,
-            InclusionProofResponse::Pending => StatusCode::ACCEPTED,
+            Self::Proof { .. } => StatusCode::OK,
+            Self::Pending => StatusCode::ACCEPTED,
         }
     }
 }

--- a/tests/integration-tests.rs
+++ b/tests/integration-tests.rs
@@ -12,7 +12,7 @@ use ethers::{
     utils::{Anvil, AnvilInstance},
 };
 use eyre::{bail, Result as EyreResult};
-use hyper::{client::HttpConnector, Body, Client, Request};
+use hyper::{client::HttpConnector, Body, Client, Request, StatusCode};
 use semaphore::poseidon_tree::PoseidonTree;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -226,6 +226,7 @@ async fn test_inclusion_proof(
             .expect("Could not parse response bytes to utf-8");
 
         if result == "\"pending\"" {
+            assert_eq!(response.status(), StatusCode::ACCEPTED);
             info!("Got pending, waiting 1 second, iteration {}", i);
             tokio::time::sleep(Duration::from_secs(1)).await;
         } else {


### PR DESCRIPTION


## Motivation

The specs were missing. This updates them, though without validation yet.

## Solution

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
