### PR TITLE
Don't wrap tx error in eyre

### DIFF
--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -4,7 +4,7 @@ pub mod caching_log_query;
 use self::abi::{MemberAddedFilter, SemaphoreContract as Semaphore};
 use crate::{
     database::Database,
-    ethereum::{Ethereum, EventError, ProviderStack},
+    ethereum::{Ethereum, EventError, ProviderStack, TxError},
 };
 use clap::Parser;
 use core::future;
@@ -183,7 +183,7 @@ impl Contracts {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub async fn insert_identity(&self, commitment: Field) -> EyreResult<TransactionReceipt> {
+    pub async fn insert_identity(&self, commitment: Field) -> Result<TransactionReceipt, TxError> {
         info!(%commitment, "Inserting identity in contract");
 
         // Send create tx


### PR DESCRIPTION
Apparently printing an eyre report can cause the app to freeze. This is a band aid, and needs a far deeper investigation.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
