### PR TITLE
Flatten proof response

### DIFF
--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -95,17 +95,14 @@ components:
     InclusionProof:
       type: object
       properties:
+        root: { $ref: '#/components/schemas/FieldElement' }
         proof:
-          type: object
-          properties:
-            root: { $ref: '#/components/schemas/FieldElement' }
-            proof:
-              type: array
-              items:
-                oneOf:
-                  - type: object
-                    properties:
-                      Left: { $ref: '#/components/schemas/FieldElement' }
-                  - type: object
-                    properties:
-                      Right: { $ref: '#/components/schemas/FieldElement' }
+          type: array
+          items:
+            oneOf:
+              - type: object
+                properties:
+                  Left: { $ref: '#/components/schemas/FieldElement' }
+              - type: object
+                properties:
+                  Right: { $ref: '#/components/schemas/FieldElement' }


### PR DESCRIPTION

## Motivation
Accidentally introduced an API incompatibility before, and it passed tests because they used the same serializer as the server. Fixed the API _and_ the tests to not have this problem in the future.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
