### PR TITLE
replace eyre with anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,9 +407,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -425,9 +425,9 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "sync_wrapper",
- "tokio",
  "tower",
  "tower-http",
  "tower-layer",
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
 dependencies = [
  "async-trait",
  "bytes",
@@ -446,6 +446,7 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -3089,9 +3090,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "md-5"
@@ -3984,9 +3985,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
+checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3994,9 +3995,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8b442418ea0822409d9e7d047cbf1e7e9e1760b172bf9982cf29d517c93511"
+checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
 dependencies = [
  "bytes",
  "heck",
@@ -4863,6 +4864,7 @@ dependencies = [
 name = "signup-sequencer"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-stream",
  "async-trait",
  "chrono",
@@ -5492,9 +5494,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b9af819e54b8f33d453655bef9b9acc171568fb49523078d0cc4e7484200ec"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5524,9 +5526,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c6fd7c2581e36d63388a9e04c350c21beb7a8b059580b2e93993c526899ddc"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ path = "criterion.rs"
 required-features = ["bench", "proptest"]
 
 [dependencies]
+anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.53"
 chrono = "0.4.19"
@@ -35,7 +36,6 @@ cli-batteries = { version = "0.4.0", features = [ "signals", "prometheus", "mete
 criterion = { version = "0.4", optional = true, features = [ "async_tokio" ] } # For `bench`
 ethers = { version = "1.0.0", features = [ "ws", "ipc", "openssl", "abigen" ] }
 eyre = "0.6"
-anyhow = "1.0.66"
 futures = "0.3"
 futures-util = { version = "^0.3" }
 hyper = { version = "^0.14.17", features = [ "server", "tcp", "http1", "http2" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ cli-batteries = { version = "0.4.0", features = [ "signals", "prometheus", "mete
 criterion = { version = "0.4", optional = true, features = [ "async_tokio" ] } # For `bench`
 ethers = { version = "1.0.0", features = [ "ws", "ipc", "openssl", "abigen" ] }
 eyre = "0.6"
+anyhow = "1.0.66"
 futures = "0.3"
 futures-util = { version = "^0.3" }
 hyper = { version = "^0.14.17", features = [ "server", "tcp", "http1", "http2" ] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,11 +6,11 @@ use crate::{
     server::{Error as ServerError, ToResponseCode},
     timed_read_progress_lock::TimedReadProgressLock,
 };
+use anyhow::Result as AnyhowResult;
 use clap::Parser;
 use cli_batteries::await_shutdown;
 use core::cmp::max;
 use ethers::types::U256;
-use anyhow::Result as AnyhowResult;
 use futures::{pin_mut, StreamExt, TryFutureExt, TryStreamExt};
 use hyper::StatusCode;
 use semaphore::{

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use cli_batteries::await_shutdown;
 use core::cmp::max;
 use ethers::types::U256;
-use eyre::Result as EyreResult;
+use anyhow::Result as AnyhowResult;
 use futures::{pin_mut, StreamExt, TryFutureExt, TryStreamExt};
 use hyper::StatusCode;
 use semaphore::{
@@ -125,7 +125,7 @@ impl App {
     /// `options.storage_file` is not accessible.
     #[allow(clippy::missing_panics_doc)] // TODO
     #[instrument(name = "App::new", level = "debug")]
-    pub async fn new(options: Options) -> EyreResult<Self> {
+    pub async fn new(options: Options) -> AnyhowResult<Self> {
         // Connect to Ethereum and Database
         let (database, (ethereum, contracts)) = {
             let db = Database::new(options.database);
@@ -526,7 +526,7 @@ impl App {
     ///
     /// Will return an Error if any of the components cannot be shut down
     /// gracefully.
-    pub async fn shutdown(&self) -> eyre::Result<()> {
+    pub async fn shutdown(&self) -> AnyhowResult<()> {
         info!("Shutting down identity committer.");
         self.identity_committer.shutdown().await
     }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -6,13 +6,13 @@ use crate::{
     database::Database,
     ethereum::{Ethereum, EventError, ProviderStack, TxError},
 };
+use anyhow::{anyhow, Result as AnyhowResult};
 use clap::Parser;
 use core::future;
 use ethers::{
     providers::Middleware,
     types::{Address, TransactionReceipt, U256},
 };
-use anyhow::{anyhow, Result as AnyhowResult};
 use futures::{Stream, StreamExt, TryStreamExt};
 use semaphore::Field;
 use std::sync::Arc;

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,6 +1,6 @@
 use crate::app::Hash;
 use clap::Parser;
-use eyre::{eyre, Context, ErrReport};
+use anyhow::{anyhow, Context, Error as ErrReport};
 use ruint::{aliases::U256, uint};
 use sqlx::{
     any::AnyKind,
@@ -54,7 +54,7 @@ impl Database {
             .max_connections(options.database_max_connections)
             .connect(options.database.as_str())
             .await
-            .wrap_err("error connecting to database")?;
+            .map_err(|e| anyhow!("error connecting to database: {}", e))?;
 
         // Log DB version to test connection.
         let sql = match pool.any_kind() {
@@ -68,7 +68,7 @@ impl Database {
         let version = pool
             .fetch_one(format!("SELECT {sql};").as_str())
             .await
-            .wrap_err("error getting database version")?
+            .map_err(|e| anyhow!("error getting database version: {}", e))?
             .get::<String, _>(0);
         info!(url = %&options.database, kind = ?pool.any_kind(), ?version, "Connected to database");
 
@@ -89,7 +89,7 @@ impl Database {
                     expected = latest,
                     "Database is in incomplete migration state.",
                 );
-                return Err(eyre!("Database is in incomplete migration state."));
+                return Err(anyhow!("Database is in incomplete migration state."));
             } else if version < latest {
                 error!(
                     url = %&options.database,
@@ -97,7 +97,7 @@ impl Database {
                     expected = latest,
                     "Database is not up to date, try rerunning with --database-migrate",
                 );
-                return Err(eyre!(
+                return Err(anyhow!(
                     "Database is not up to date, try rerunning with --database-migrate"
                 ));
             } else if version > latest {
@@ -107,7 +107,7 @@ impl Database {
                     latest,
                     "Database version is newer than this version of the software, please update.",
                 );
-                return Err(eyre!(
+                return Err(anyhow!(
                     "Database version is newer than this version of the software, please update."
                 ));
             }
@@ -119,7 +119,7 @@ impl Database {
             );
         } else {
             error!(url = %&options.database, "Could not get database version");
-            return Err(eyre!("Could not get database version."));
+            return Err(anyhow!("Could not get database version."));
         }
 
         Ok(Self { pool })

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,6 +1,6 @@
 use crate::app::Hash;
-use clap::Parser;
 use anyhow::{anyhow, Context, Error as ErrReport};
+use clap::Parser;
 use ruint::{aliases::U256, uint};
 use sqlx::{
     any::AnyKind,
@@ -54,7 +54,7 @@ impl Database {
             .max_connections(options.database_max_connections)
             .connect(options.database.as_str())
             .await
-            .map_err(|e| anyhow!("error connecting to database: {}", e))?;
+            .context("error connecting to database")?;
 
         // Log DB version to test connection.
         let sql = match pool.any_kind() {
@@ -68,7 +68,7 @@ impl Database {
         let version = pool
             .fetch_one(format!("SELECT {sql};").as_str())
             .await
-            .map_err(|e| anyhow!("error getting database version: {}", e))?
+            .context("error getting database version")?
             .get::<String, _>(0);
         info!(url = %&options.database, kind = ?pool.any_kind(), ?version, "Connected to database");
 

--- a/src/ethereum/mod.rs
+++ b/src/ethereum/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     contracts::caching_log_query::{CachingLogQuery, Error as CachingLogQueryError},
     database::Database,
 };
+use anyhow::{anyhow, Result as AnyhowResult};
 use chrono::{Duration as ChronoDuration, Utc};
 use clap::Parser;
 use ethers::{
@@ -33,7 +34,6 @@ use ethers::{
         BlockNumber, Chain, Filter, Log, TransactionReceipt, H160, H256, U64,
     },
 };
-use anyhow::{anyhow, Result as AnyhowResult};
 use futures::{try_join, FutureExt, Stream, StreamExt, TryStreamExt};
 use once_cell::sync::Lazy;
 use prometheus::{

--- a/src/identity_committer.rs
+++ b/src/identity_committer.rs
@@ -35,7 +35,9 @@ impl RunningInstance {
                 debug!("Committer job already scheduled.");
                 Ok(())
             }
-            Err(TrySendError::Closed(_)) => Err(anyhow!("Committer thread terminated unexpectedly.")),
+            Err(TrySendError::Closed(_)) => {
+                Err(anyhow!("Committer thread terminated unexpectedly."))
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod utils;
 
 use crate::app::App;
 use clap::Parser;
-use eyre::Result as EyreResult;
+use anyhow::Result as AnyhowResult;
 use std::sync::Arc;
 use tracing::info;
 
@@ -30,7 +30,7 @@ pub struct Options {
 /// assert!(true);
 /// ```
 #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-pub async fn main(options: Options) -> EyreResult<()> {
+pub async fn main(options: Options) -> AnyhowResult<()> {
     // Create App struct
     let app = Arc::new(App::new(options.app).await?);
     let app_for_server = app.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ mod timed_read_progress_lock;
 mod utils;
 
 use crate::app::App;
-use clap::Parser;
 use anyhow::Result as AnyhowResult;
+use clap::Parser;
 use std::sync::Arc;
 use tracing::info;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,11 @@
 
 use cli_batteries::{run, version};
 use signup_sequencer::{main as sequencer_app, Options};
-use eyre;
 
 async fn app(options: Options) -> eyre::Result<()> {
-    sequencer_app(options).await.map_err(|e| {
-        eyre::eyre!("{:?}", e)
-    })
+    sequencer_app(options)
+        .await
+        .map_err(|e| eyre::eyre!("{:?}", e))
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,14 @@
 #![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
 
 use cli_batteries::{run, version};
-use signup_sequencer::main as app;
+use signup_sequencer::{main as sequencer_app, Options};
+use eyre;
+
+async fn app(options: Options) -> eyre::Result<()> {
+    sequencer_app(options).await.map_err(|e| {
+        eyre::eyre!("{:?}", e)
+    })
+}
 
 fn main() {
     run(version!(semaphore, ethers), app);

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,9 +3,9 @@ use crate::{
     database,
 };
 use ::prometheus::{opts, register_counter, register_histogram, Counter, Histogram};
+use anyhow::{bail, ensure, Context, Error as EyreError, Result as AnyhowResult};
 use clap::Parser;
-use cli_batteries::{await_shutdown};
-use anyhow::{anyhow, bail, ensure, Error as EyreError, Result as AnyhowResult};
+use cli_batteries::await_shutdown;
 use futures::Future;
 use hyper::{
     body::Buf,
@@ -173,7 +173,7 @@ where
 
 #[instrument(level="info", name="api_request", skip(app), fields(http.uri=%request.uri(), http.method=%request.method()))]
 async fn route(request: Request<Body>, app: Arc<App>) -> Result<Response<Body>, hyper::Error> {
-    //trace_from_headers(request.headers());
+    // trace_from_headers(request.headers());
 
     // Measure and log request
     let _timer = LATENCY.start_timer(); // Observes on drop
@@ -288,7 +288,7 @@ pub async fn bind_from_listener(
     });
 
     let server = Server::from_tcp(listener)
-        .map_err(|e| anyhow!("Failed to bind address: {}", e))?
+        .context("Failed to bind address")?
         .serve(make_svc)
         .with_graceful_shutdown(await_shutdown());
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use ::prometheus::{opts, register_counter, register_histogram, Counter, Histogram};
 use clap::Parser;
-use cli_batteries::{await_shutdown, trace_from_headers};
-use eyre::{bail, ensure, Error as EyreError, Result as EyreResult, WrapErr as _};
+use cli_batteries::{await_shutdown};
+use anyhow::{anyhow, bail, ensure, Error as EyreError, Result as AnyhowResult};
 use futures::Future;
 use hyper::{
     body::Buf,
@@ -173,7 +173,7 @@ where
 
 #[instrument(level="info", name="api_request", skip(app), fields(http.uri=%request.uri(), http.method=%request.method()))]
 async fn route(request: Request<Body>, app: Arc<App>) -> Result<Response<Body>, hyper::Error> {
-    trace_from_headers(request.headers());
+    //trace_from_headers(request.headers());
 
     // Measure and log request
     let _timer = LATENCY.start_timer(); // Observes on drop
@@ -222,7 +222,7 @@ async fn route(request: Request<Body>, app: Arc<App>) -> Result<Response<Body>, 
 /// Will return `Err` if `options.server` URI is not http, incorrectly includes
 /// a path beyond `/`, or cannot be cast into an IP address. Also returns an
 /// `Err` if the server cannot bind to the given address.
-pub async fn main(app: Arc<App>, options: Options) -> EyreResult<()> {
+pub async fn main(app: Arc<App>, options: Options) -> AnyhowResult<()> {
     ensure!(
         options.server.scheme() == "http",
         "Only http:// is supported in {}",
@@ -262,7 +262,7 @@ pub async fn bind_from_listener(
     app: Arc<App>,
     serve_timeout: Duration,
     listener: TcpListener,
-) -> EyreResult<()> {
+) -> AnyhowResult<()> {
     let local_addr = listener.local_addr()?;
     let make_svc = make_service_fn(move |_| {
         // Clone here as `make_service_fn` is called for every connection
@@ -288,7 +288,7 @@ pub async fn bind_from_listener(
     });
 
     let server = Server::from_tcp(listener)
-        .wrap_err("Failed to bind address")?
+        .map_err(|e| anyhow!("Failed to bind address: {}", e))?
         .serve(make_svc)
         .with_graceful_shutdown(await_shutdown());
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
-use ethers::types::U256;
 use anyhow::{Error as EyreError, Result as AnyhowResult};
+use ethers::types::U256;
 use futures::FutureExt;
 use std::future::Future;
 use tokio::task::JoinHandle;

--- a/tests/integration-tests.rs
+++ b/tests/integration-tests.rs
@@ -11,7 +11,7 @@ use ethers::{
     types::{H256, U256},
     utils::{Anvil, AnvilInstance},
 };
-use eyre::{bail, Result as EyreResult};
+use eyre::{bail, Result as AnyhowResult};
 use hyper::{client::HttpConnector, Body, Client, Request, StatusCode};
 use semaphore::{merkle_tree::Branch, poseidon_tree::PoseidonTree};
 use serde::{Deserialize, Serialize};
@@ -311,7 +311,7 @@ fn construct_insert_identity_body(identity_commitment: &str) -> Body {
 }
 
 #[instrument(skip_all)]
-async fn spawn_app(options: Options) -> EyreResult<(JoinHandle<()>, SocketAddr)> {
+async fn spawn_app(options: Options) -> AnyhowResult<(JoinHandle<()>, SocketAddr)> {
     let app = App::new(options.app).await.expect("Failed to create App");
 
     let ip: IpAddr = match options.server.server.host() {
@@ -344,7 +344,7 @@ struct CompiledContract {
     bytecode: String,
 }
 
-fn deserialize_to_bytes(input: String) -> EyreResult<Bytes> {
+fn deserialize_to_bytes(input: String) -> AnyhowResult<Bytes> {
     if input.len() >= 2 && &input[0..2] == "0x" {
         let bytes: Vec<u8> = hex::decode(&input[2..])?;
         Ok(bytes.into())
@@ -354,7 +354,7 @@ fn deserialize_to_bytes(input: String) -> EyreResult<Bytes> {
 }
 
 #[instrument(skip_all)]
-async fn spawn_mock_chain() -> EyreResult<(AnvilInstance, H256, Address)> {
+async fn spawn_mock_chain() -> AnyhowResult<(AnvilInstance, H256, Address)> {
     let chain = Anvil::new().block_time(2u64).spawn();
     let private_key = H256::from_slice(&chain.keys()[0].to_be_bytes());
 


### PR DESCRIPTION
Following up on https://github.com/worldcoin/signup-sequencer/pull/295, we had another instance where logging `eyre::Report` with `tracing` and `otlp` enabled completely hanged the app (and prevented it from restarting successfully).

It looks like `anyhow` doesn't have this problem. We can continue investigating what exactly causes OTLP and eyre to misbehave so badly, but for now this should fix the production.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
