### PR TITLE
re-enable trace_from_headers function

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,7 @@ use crate::{
 use ::prometheus::{opts, register_counter, register_histogram, Counter, Histogram};
 use anyhow::{bail, ensure, Context, Error as EyreError, Result as AnyhowResult};
 use clap::Parser;
-use cli_batteries::await_shutdown;
+use cli_batteries::{await_shutdown, trace_from_headers};
 use futures::Future;
 use hyper::{
     body::Buf,
@@ -173,7 +173,7 @@ where
 
 #[instrument(level="info", name="api_request", skip(app), fields(http.uri=%request.uri(), http.method=%request.method()))]
 async fn route(request: Request<Body>, app: Arc<App>) -> Result<Response<Body>, hyper::Error> {
-    // trace_from_headers(request.headers());
+    trace_from_headers(request.headers());
 
     // Measure and log request
     let _timer = LATENCY.start_timer(); // Observes on drop


### PR DESCRIPTION
It was commented out in https://github.com/worldcoin/signup-sequencer/pull/307 by accident while testing whether `otlp` was the culprit.

In my testing, `trace_from_headers`, `anyhow`, `oltp` together don't cause any issues.

/ cc @recmo 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
