### PR TITLE
Better cache invalidation, longer confirmation delay

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -144,7 +144,6 @@ impl App {
         }
 
         // Basic sanity checks on the merkle tree
-        app.chain_subscriber.check_leaves().await;
         app.chain_subscriber.check_health().await;
 
         // Listen to Ethereum events

--- a/src/app.rs
+++ b/src/app.rs
@@ -169,7 +169,7 @@ impl App {
                     .delete_most_recent_cached_events(cache_recovery_step_size as i64)
                     .await?;
             } else if root_mismatch_count == 2 {
-                error!(cache_recovery_step_size, "Wiping out the entire cache.");
+                error!("Wiping out the entire cache.");
                 self.database.wipe_cache().await?;
             } else if root_mismatch_count >= 3 {
                 return Err(SubscriberError::RootMismatch.into());

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -339,6 +339,14 @@ impl Database {
             .map_err(Error::InternalError)?;
         Ok(())
     }
+
+    pub async fn wipe_cache(&self) -> Result<(), Error> {
+        self.pool
+            .execute(sqlx::query("DELETE FROM logs;"))
+            .await
+            .map_err(Error::InternalError)?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Error)]

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -324,9 +324,17 @@ impl Database {
         Ok(())
     }
 
-    pub async fn wipe_cache(&self) -> Result<(), Error> {
+    pub async fn delete_most_recent_cached_events(
+        &self,
+        recovery_step_size: i64,
+    ) -> Result<(), Error> {
+        let max_block_number =
+            i64::try_from(self.get_block_number().await?).expect("block number must be i64");
         self.pool
-            .execute(sqlx::query("DELETE FROM logs;"))
+            .execute(
+                sqlx::query("DELETE FROM logs WHERE block_index >= $1;")
+                    .bind(max_block_number - recovery_step_size),
+            )
             .await
             .map_err(Error::InternalError)?;
         Ok(())

--- a/src/ethereum/mod.rs
+++ b/src/ethereum/mod.rs
@@ -118,7 +118,7 @@ pub struct Options {
     pub max_backoff_time: Duration,
 
     /// Minimum number of blocks before events are considered confirmed.
-    #[clap(long, env, default_value = "10")]
+    #[clap(long, env, default_value = "35")]
     pub confirmation_blocks_delay: usize,
 
     /// The number of most recent blocks to be removed from cache on root

--- a/src/ethereum/mod.rs
+++ b/src/ethereum/mod.rs
@@ -121,6 +121,11 @@ pub struct Options {
     #[clap(long, env, default_value = "10")]
     pub confirmation_blocks_delay: usize,
 
+    /// The number of most recent blocks to be removed from cache on root
+    /// mismatch
+    #[clap(long, env, default_value = "1000")]
+    pub cache_recovery_step_size: usize,
+
     /// Frequency of event fetching from Ethereum (seconds)
     #[clap(long, env, value_parser=duration_from_str, default_value="60")]
     pub refresh_rate: Duration,

--- a/src/ethereum_subscriber.rs
+++ b/src/ethereum_subscriber.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use futures::{StreamExt, TryStreamExt};
 use semaphore::Field;
-use std::{cmp::min, collections::HashMap, sync::Arc, time::Duration};
+use std::{cmp::min, sync::Arc, time::Duration};
 use thiserror::Error;
 use tokio::{sync::RwLock, task::JoinHandle, time::sleep};
 use tracing::{error, info, instrument, warn};

--- a/src/ethereum_subscriber.rs
+++ b/src/ethereum_subscriber.rs
@@ -288,6 +288,19 @@ impl EthereumSubscriber {
             return Ok(());
         }
 
+        // Check duplicates
+        if let Some(previous) = tree.merkle_tree.leaves()[..index]
+            .iter()
+            .position(|l| l == leaf)
+        {
+            error!(
+                ?index,
+                ?leaf,
+                ?previous,
+                "Received event for already inserted leaf."
+            );
+        }
+
         Ok(())
     }
 

--- a/src/ethereum_subscriber.rs
+++ b/src/ethereum_subscriber.rs
@@ -292,42 +292,6 @@ impl EthereumSubscriber {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub async fn check_leaves(&self) {
-        let tree = self.tree_state.read().await.unwrap_or_else(|e| {
-            error!(?e, "Failed to obtain tree lock in check_leaves.");
-            panic!("Sequencer potentially deadlocked, terminating.");
-        });
-        let next_leaf = tree.next_leaf;
-        let initial_leaf = self.contracts.initial_leaf();
-
-        let mut visited_identities = HashMap::<Field, usize>::new();
-        for (index, &leaf) in tree.merkle_tree.leaves().iter().enumerate() {
-            if index < next_leaf && leaf == initial_leaf {
-                error!(
-                    ?index,
-                    ?leaf,
-                    ?next_leaf,
-                    "Leaf in non-empty spot set to initial leaf value."
-                );
-            }
-            if index >= next_leaf && leaf != initial_leaf {
-                error!(
-                    ?index,
-                    ?leaf,
-                    ?next_leaf,
-                    "Leaf in empty spot not set to initial leaf value."
-                );
-            }
-            if leaf != initial_leaf {
-                if let Some(previous) = visited_identities.get(&leaf) {
-                    error!(?index, ?leaf, ?previous, "Leaf not unique.");
-                }
-            }
-            visited_identities.insert(leaf, index);
-        }
-    }
-
-    #[instrument(level = "debug", skip_all)]
     pub async fn check_health(&self) {
         let tree = self.tree_state.read().await.unwrap_or_else(|e| {
             error!(?e, "Failed to obtain tree lock in check_leaves.");


### PR DESCRIPTION
This does a few things:
* increase confirmation delay to 35 blocks to have fewer failures on polygon
* stop logging errors for leaves that we already know are empty or duplicated. only log new errors.
* increase cache resiliency by multi-stage recovery:
    * start with the full cache loaded; on root mismatch:
    * remove the most recent 1000 cached blocks; on root mismatch:
    * remove the entire cache; on root mismatch:
    * restart app.

Example from my local sequencer:
* root mismatch 100 blocks from the head:
    <img width="669" alt="Screenshot 2023-01-11 at 14 57 31" src="https://user-images.githubusercontent.com/35899/211825974-16f45989-b024-4229-9a90-da4f5df338a9.png">
* root mismatch more than 1000 blocks from the head:
    <img width="523" alt="Screenshot 2023-01-11 at 15 03 16" src="https://user-images.githubusercontent.com/35899/211826045-445f488e-2680-42e4-bbf0-5c708633bc7b.png">

