### PR TITLE
Freeze docker buildx version

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -208,6 +208,8 @@ jobs:
         run: echo ${{ steps.qemu.outputs.platforms }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Our CI died because of upstream changes in other actions. Freezing to the non-broken version. 