### PR TITLE
Initial Refactoring for Batching Integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-# Please adjust all these values, including the license
 name = "signup-sequencer"
 version = "0.1.0"
 authors = [
@@ -9,14 +8,15 @@ edition = "2021"
 build = "build.rs"
 homepage = "https://github.com/worldcoin/signup-sequencer"
 repository = "https://github.com/worldcoin/signup-sequencer"
-description = "Template for a Rust CLI tool"
+description = "A tool that processes WorldID signups on-chain."
 keywords = ["worldcoin", "protocol", "signup"]
 categories = ["cryptography::cryptocurrencies"]
 readme = "Readme.md"
 license-file = "mit-license.md"
 
 [features]
-default = [ ]
+default = []
+batching-contract = []
 bench = ["criterion", "proptest"]
 mimalloc = ["cli-batteries/mimalloc"]
 
@@ -27,29 +27,29 @@ path = "criterion.rs"
 required-features = ["bench", "proptest"]
 
 [dependencies]
-anyhow = "1.0.68"
+anyhow = { version = "1.0.68" }
 async-stream = "0.3.3"
 async-trait = "0.1.60"
 chrono = "0.4.19"
-clap = { version = "4.0", features = [ "derive" ] }
-cli-batteries = { version = "0.4.0", features = [ "signals", "prometheus", "metered-allocator", "otlp" ] }
-criterion = { version = "0.4", optional = true, features = [ "async_tokio" ] } # For `bench`
-ethers = { version = "1.0.0", features = [ "ws", "ipc", "openssl", "abigen" ] }
+clap = { version = "4.0", features = ["derive"] }
+cli-batteries = { version = "0.4.0", features = ["signals", "prometheus", "metered-allocator", "otlp"] }
+criterion = { version = "0.4", optional = true, features = ["async_tokio"] } # For `bench`
+ethers = { version = "1.0.0", features = ["ws", "ipc", "openssl", "abigen"] }
 eyre = "0.6"
 futures = "0.3"
 futures-util = { version = "^0.3" }
-hyper = { version = "^0.14.17", features = [ "server", "tcp", "http1", "http2" ] }
+hyper = { version = "^0.14.17", features = ["server", "tcp", "http1", "http2"] }
 once_cell = "1.8"
 prometheus = "0.13.3" # We need upstream PR#465 to fix #272.
 proptest = { version = "1.0", optional = true } # For `bench`
 reqwest = "0.11.10"
 ruint = { version = "1.3", features = ["primitive-types", "sqlx"] }
 semaphore = { git = "https://github.com/worldcoin/semaphore-rs", branch = "main" }
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls", "any", "sqlite", "postgres" ] }
+sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "any", "sqlite", "postgres"] }
 thiserror = "1.0"
-tokio = { version = "1.17", features = [ "signal", "macros", "rt", "sync", "time", "rt-multi-thread", "tracing" ] }
+tokio = { version = "1.17", features = ["signal", "macros", "rt", "sync", "time", "rt-multi-thread", "tracing"] }
 tracing = "0.1"
 tracing-futures = "0.2"
 url = "2.2"
@@ -58,7 +58,7 @@ url = "2.2"
 # `cargo update --package primitive-types@0.12.1 --precise 0.11.1`
 
 [dev-dependencies]
-cli-batteries = { version = "0.4.0", features = [ "mock-shutdown" ] }
+cli-batteries = { version = "0.4.0", features = ["mock-shutdown"] }
 hex = "0.4.3"
 hex-literal = "0.3"
 proptest = { version = "1.0" }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 fn main() {
     cli_batteries::build_rs().unwrap();
 
+    println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=schemas");
+    println!("cargo:rerun-if-changed=sol");
 }

--- a/deploy/Chart.yaml
+++ b/deploy/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 version: "0.1.0"
 name: signup-sequencer
 appVersion: "0.1.0"
-description: "Template for a Rust CLI tool"
+description: "A tool that processes WorldID signups on-chain."
 home: https://github.com/worldcoin/signup-sequencer
 sources:
   - https://github.com/worldcoin/signup-sequencer

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use crate::{
-    contracts::{self, Contracts},
+    contracts,
+    contracts::{legacy::Contract as LegacyContract, IdentityManager, SharedIdentityManager},
     database::{self, Database},
     ethereum::{self, Ethereum},
     ethereum_subscriber::{Error as SubscriberError, EthereumSubscriber},
@@ -76,7 +77,7 @@ pub struct App {
     database:           Arc<Database>,
     #[allow(dead_code)]
     ethereum:           Ethereum,
-    contracts:          Arc<Contracts>,
+    identity_manager:   SharedIdentityManager,
     identity_committer: Arc<IdentityCommitter>,
     #[allow(dead_code)]
     chain_subscriber:   EthereumSubscriber,
@@ -95,12 +96,16 @@ impl App {
         let cache_recovery_step_size = options.ethereum.cache_recovery_step_size;
 
         // Connect to Ethereum and Database
-        let (database, (ethereum, contracts)) = {
+        let (database, (ethereum, identity_manager)) = {
             let db = Database::new(options.database);
 
             let eth = Ethereum::new(options.ethereum).and_then(|ethereum| async move {
-                let contracts = Contracts::new(options.contracts, ethereum.clone()).await?;
-                Ok((ethereum, Arc::new(contracts)))
+                let identity_manager = if cfg!(feature = "batching-contract") {
+                    panic!("The batching contract does not yet exist but was requested.");
+                } else {
+                    LegacyContract::new(options.contracts, ethereum.clone()).await?
+                };
+                Ok((ethereum, Arc::new(identity_manager)))
             });
 
             // Connect to both in parallel
@@ -112,18 +117,21 @@ impl App {
         // Poseidon tree depth is one more than the contract's tree depth
         let tree_state = Arc::new(TimedRwLock::new(
             Duration::from_secs(options.lock_timeout),
-            TreeState::new(contracts.tree_depth() + 1, contracts.initial_leaf()),
+            TreeState::new(
+                identity_manager.tree_depth() + 1,
+                identity_manager.initial_leaf_value(),
+            ),
         ));
 
         let identity_committer = Arc::new(IdentityCommitter::new(
             database.clone(),
-            contracts.clone(),
+            identity_manager.clone(),
             tree_state.clone(),
         ));
         let chain_subscriber = EthereumSubscriber::new(
             options.starting_block,
             database.clone(),
-            contracts.clone(),
+            identity_manager.clone(),
             tree_state.clone(),
             identity_committer.clone(),
         );
@@ -132,7 +140,7 @@ impl App {
         let mut app = Self {
             database,
             ethereum,
-            contracts,
+            identity_manager,
             identity_committer,
             chain_subscriber,
             tree_state,
@@ -184,8 +192,8 @@ impl App {
                     self.tree_state = Arc::new(TimedRwLock::new(
                         Duration::from_secs(lock_timeout),
                         TreeState::new(
-                            self.contracts.tree_depth() + 1,
-                            self.contracts.initial_leaf(),
+                            self.identity_manager.tree_depth() + 1,
+                            self.identity_manager.initial_leaf_value(),
                         ),
                     ));
 
@@ -193,7 +201,7 @@ impl App {
                     self.chain_subscriber = EthereumSubscriber::new(
                         starting_block,
                         self.database.clone(),
-                        self.contracts.clone(),
+                        self.identity_manager.clone(),
                         self.tree_state.clone(),
                         self.identity_committer.clone(),
                     );
@@ -216,11 +224,11 @@ impl App {
         group_id: usize,
         commitment: Hash,
     ) -> Result<(), ServerError> {
-        if U256::from(group_id) != self.contracts.group_id() {
+        if U256::from(group_id) != self.identity_manager.group_id() {
             return Err(ServerError::InvalidGroupId);
         }
 
-        if commitment == self.contracts.initial_leaf() {
+        if commitment == self.identity_manager.initial_leaf_value() {
             warn!(?commitment, "Attempt to insert initial leaf.");
             return Err(ServerError::InvalidCommitment);
         }
@@ -269,11 +277,11 @@ impl App {
         group_id: usize,
         commitment: &Hash,
     ) -> Result<InclusionProofResponse, ServerError> {
-        if U256::from(group_id) != self.contracts.group_id() {
+        if U256::from(group_id) != self.identity_manager.group_id() {
             return Err(ServerError::InvalidGroupId);
         }
 
-        if commitment == &self.contracts.initial_leaf() {
+        if commitment == &self.identity_manager.initial_leaf_value() {
             return Err(ServerError::InvalidCommitment);
         }
 
@@ -312,7 +320,7 @@ impl App {
                 drop(tree);
 
                 // Verify the root on chain
-                if let Err(error) = self.contracts.assert_valid_root(root).await {
+                if let Err(error) = self.identity_manager.assert_valid_root(root).await {
                     error!(
                         computed_root = ?root,
                         ?error,

--- a/src/contracts/batching/abi.rs
+++ b/src/contracts/batching/abi.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::extra_unused_lifetimes)]
+
+use ethers::prelude::abigen;
+
+abigen!(
+    BatchingContract,
+    r#"[
+        function NO_SUCH_ROOT() public pure returns ((uint256 root, uint128 supersededTimestamp, bool isValid) memory rootInfo)
+        error UnreducedElement(uint8 elementType, uint256 element)
+        error Unauthorized(address user)
+        error InvalidCommitment(uint256 commitment)
+        error ProofValidationFailure()
+        error NotLatestRoot(uint256 providedRoot, uint256 latestRoot)
+        error ExpiredRoot()
+        error NonExistentRoot()
+        error ImplementationNotInitalized()
+        constructor(address _logic, bytes memory data) payable
+        function initialize(uint256 initialRoot, address merkleTreeVerifier_) public virtual
+        function registerIdentities(uint256[8] calldata insertionProof, uint256 preRoot, uint32 startIndex, uint256[] calldata identityCommitments, uint256 postRoot) public virtual
+        function calculateTreeVerifierInputHash(uint32 startIndex, uint256 preRoot, uint256 postRoot, uint256[] identityCommitments) public view virtual returns (bytes32 hash)
+        function latestRoot() public view virtual returns (uint256 root)
+        function queryRoot(uint256 root) public view virtual returns ((uint256 root, uint128 supersededTimestamp, bool isValid) memory rootInfo)
+        function isInputInReducedForm(uint256 input) public view virtual returns (bool isInReducedForm)
+        function checkValidRoot(uint256 root) public view virtual returns (bool)
+        function verifyProof(uint256 root, uint256 signalHash, uint256 nullifierHash, uint256 externalNullifierHash, uint256[8] calldata proof) public view virtual
+        function owner() public view virtual returns (address)
+        function renounceOwnership() public virtual
+        function transferOwnership(address newOwner) public virtual
+        function proxiableUUID() external view virtual override returns (bytes32)
+        function upgradeTo(address newImplementation) external virtual
+        function upgradeToAndCall(address newImplementation, bytes memory data) external payable virtual
+    ]"#,
+    event_derives(serde::Deserialize, serde::Serialize)
+);

--- a/src/contracts/batching/mod.rs
+++ b/src/contracts/batching/mod.rs
@@ -1,0 +1,127 @@
+mod abi;
+
+use self::abi::BatchingContract as ContractAbi;
+use crate::{
+    contracts::{EventStream, IdentityManager, Options},
+    ethereum::{Ethereum, EventError, ProviderStack, TxError},
+    tx_sitter::Sitter,
+};
+use async_trait::async_trait;
+use ethers::{
+    providers::Middleware,
+    types::{TransactionReceipt, U256},
+};
+use semaphore::Field;
+use tracing::{error, info, instrument};
+
+// TODO [Ara] Remove the allows.
+/// A structure representing the interface to the batch-based identity manager
+/// contract.
+pub struct Contract {
+    #[allow(dead_code)]
+    ethereum: Ethereum,
+    #[allow(dead_code)]
+    sitter:   Sitter,
+    #[allow(dead_code)]
+    abi:      ContractAbi<ProviderStack>,
+}
+
+#[async_trait]
+impl IdentityManager for Contract {
+    #[instrument(level = "debug", skip_all)]
+    async fn new(options: Options, ethereum: Ethereum) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        // Check that there is code deployed at the target address.
+        let address = options.identity_manager_address;
+        let code = ethereum.provider().get_code(address, None).await?;
+        if code.as_ref().is_empty() {
+            error!(
+                ?address,
+                "No contract code is deployed at the provided address."
+            );
+        }
+
+        // Connect to the running batching contract.
+        let abi = ContractAbi::new(
+            options.identity_manager_address,
+            ethereum.provider().clone(),
+        );
+
+        let owner = abi.owner().call().await?;
+        if owner != ethereum.address() {
+            error!(?owner, signer = ?ethereum.address(), "Signer is not the owner of the identity manager contract.");
+            panic!("Cannot currently continue in read-only mode.")
+        }
+        info!(
+            ?address,
+            ?owner,
+            "Connected to the WorldID Identity Manager"
+        );
+
+        let sitter = Sitter::new(ethereum.clone()).await?;
+
+        let identity_manager = Self {
+            ethereum,
+            sitter,
+            abi,
+        };
+
+        Ok(identity_manager)
+    }
+
+    fn tree_depth(&self) -> usize {
+        todo!()
+    }
+
+    fn initial_leaf_value(&self) -> Field {
+        todo!()
+    }
+
+    fn group_id(&self) -> U256 {
+        todo!()
+    }
+
+    async fn confirmed_block_number(&self) -> Result<u64, EventError> {
+        self.ethereum
+            .confirmed_block_number()
+            .await
+            .map(|num| num.as_u64())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn is_owner(&self) -> anyhow::Result<bool> {
+        info!(address = ?self.ethereum.address(), "My address");
+        let owner = self.abi.owner().call().await?;
+        info!(?owner, "Fetched owner address");
+        Ok(owner == self.ethereum.address())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn register_identities(
+        &self,
+        _identity_commitments: Vec<Field>,
+    ) -> Result<TransactionReceipt, TxError> {
+        todo!()
+    }
+
+    async fn assert_latest_root(&self, root: Field) -> anyhow::Result<()> {
+        let latest_root = self.abi.latest_root().call().await?;
+        let processed_root: U256 = root.into();
+        if processed_root == latest_root {
+            Ok(())
+        } else {
+            Err(anyhow::Error::msg("Not latest root."))
+        }
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn assert_valid_root(&self, _root: Field) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    fn fetch_events(&self, _: u64, _: Option<u64>) -> Option<EventStream<'_>> {
+        None
+    }
+}

--- a/src/contracts/legacy/abi.rs
+++ b/src/contracts/legacy/abi.rs
@@ -3,7 +3,7 @@
 use ethers::contract::abigen;
 
 abigen!(
-    SemaphoreContract,
+    LegacyContract,
     r#"[
         event MemberAdded(uint256 indexed groupId, uint256 identityCommitment, uint256 root)
         function manager() public view returns (address)

--- a/src/contracts/legacy/mod.rs
+++ b/src/contracts/legacy/mod.rs
@@ -1,0 +1,206 @@
+mod abi;
+
+use self::abi::{LegacyContract as ContractAbi, MemberAddedFilter};
+use crate::{
+    contracts::{EventStream, IdentityManager, Options},
+    ethereum::{Ethereum, EventError, ProviderStack, TxError},
+    tx_sitter::Sitter,
+};
+use anyhow::anyhow;
+use async_trait::async_trait;
+use core::future;
+use ethers::{
+    providers::Middleware,
+    types::{TransactionReceipt, U256},
+};
+use futures::TryStreamExt;
+use semaphore::Field;
+use tracing::{error, info, instrument};
+
+pub type MemberAddedEvent = MemberAddedFilter;
+
+/// A structure representing the interface to the legacy identity manager
+/// contract.
+pub struct Contract {
+    ethereum:     Ethereum,
+    sitter:       Sitter,
+    abi:          ContractAbi<ProviderStack>,
+    group_id:     U256,
+    tree_depth:   usize,
+    initial_leaf: Field,
+}
+
+#[async_trait]
+impl IdentityManager for Contract {
+    #[instrument(level = "debug", skip_all)]
+    async fn new(options: Options, ethereum: Ethereum) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        // Sanity check the address
+        // TODO: Check that the contract is actually a Semaphore by matching bytecode.
+        let address = options.identity_manager_address;
+        let code = ethereum.provider().get_code(address, None).await?;
+        if code.as_ref().is_empty() {
+            error!(
+                ?address,
+                "No contract code deployed at provided Semaphore address"
+            );
+            return Err(anyhow!("Invalid Semaphore address"));
+        }
+
+        // Connect to Contract
+        let semaphore = ContractAbi::new(
+            options.identity_manager_address,
+            ethereum.provider().clone(),
+        );
+
+        // Test contract by calling a view function and make sure we are manager.
+        let manager = semaphore.manager().call().await?;
+        if manager != ethereum.address() {
+            error!(?manager, signer = ?ethereum.address(), "Signer is not the manager of the Semaphore contract");
+            // return Err(anyhow!("Signer is not manager"));
+            // TODO: If not manager, proceed in read-only mode.
+        }
+        info!(?address, ?manager, "Connected to Semaphore contract");
+
+        let sitter = Sitter::new(ethereum.clone()).await?;
+
+        // Make sure the group exists.
+        let existing_tree_depth = semaphore.get_depth(options.group_id).call().await?;
+        let actual_tree_depth = if existing_tree_depth == 0 {
+            if let Some(new_depth) = options.create_group_depth {
+                let tx = semaphore
+                    .create_group(
+                        options.group_id,
+                        new_depth.try_into()?,
+                        options.initial_leaf_value.to_be_bytes().into(),
+                    )
+                    .tx;
+                sitter.send(tx).await?;
+                new_depth
+            } else {
+                error!(group_id = ?options.group_id, "Group does not exist");
+                return Err(anyhow!("Group does not exist"));
+            }
+        } else {
+            info!(group_id = ?options.group_id, ?existing_tree_depth, "Semaphore group found.");
+            usize::from(existing_tree_depth)
+        };
+
+        // TODO: Some way to check the initial leaf
+
+        let identity_manager = Self {
+            ethereum,
+            sitter,
+            abi: semaphore,
+            group_id: options.group_id,
+            tree_depth: actual_tree_depth,
+            initial_leaf: options.initial_leaf_value,
+        };
+
+        Ok(identity_manager)
+    }
+
+    fn tree_depth(&self) -> usize {
+        self.tree_depth
+    }
+
+    fn initial_leaf_value(&self) -> Field {
+        self.initial_leaf
+    }
+
+    fn group_id(&self) -> U256 {
+        self.group_id
+    }
+
+    async fn confirmed_block_number(&self) -> Result<u64, EventError> {
+        self.ethereum
+            .confirmed_block_number()
+            .await
+            .map(|num| num.as_u64())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn is_owner(&self) -> anyhow::Result<bool> {
+        info!(address = ?self.ethereum.address(), "My address");
+        let manager = self.abi.manager().call().await?;
+        info!(?manager, "Fetched manager address");
+        Ok(manager == self.ethereum.address())
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn register_identities(
+        &self,
+        identity_commitments: Vec<Field>,
+    ) -> Result<TransactionReceipt, TxError> {
+        // TODO Make this loop over identities if it gets multiple.
+        assert_eq!(
+            identity_commitments.len(),
+            1,
+            "The legacy identity manager can only accept single commitments."
+        );
+        let identity = identity_commitments.first().unwrap();
+
+        // Send the registration transaction
+        let commitment = U256::from(identity.to_be_bytes());
+        let receipt = self
+            .sitter
+            .send(self.abi.add_member(self.group_id, commitment).tx)
+            .await?;
+        Ok(receipt)
+    }
+
+    async fn assert_latest_root(&self, _: Field) -> anyhow::Result<()> {
+        Err(anyhow::Error::msg(
+            "Unsupported operation: assert_latest_root",
+        ))
+    }
+
+    // This is a total hack due to the contract not supporting a `get_root`
+    // function.
+    #[instrument(level = "debug", skip_all)]
+    async fn assert_valid_root(&self, root: Field) -> anyhow::Result<()> {
+        // HACK: Abuse the `verifyProof` function.
+
+        let result = self
+            .abi
+            .verify_proof(
+                root.to_be_bytes().into(),
+                self.group_id,
+                U256::zero(),
+                U256::zero(),
+                U256::zero(),
+                [U256::zero(); 8],
+            )
+            .call()
+            .await
+            .expect_err("Proof is invalid");
+        // Result will be either `0x09bde339`: `InvalidProof()` (good) or
+        // `0x504570e3`: `InvalidRoot()` (bad).
+        // See <https://github.com/worldcoin/world-id-example-airdrop/blob/03de53d2cb016ddef28b26e8237e85b62ec385c7/src/Semaphore.sol#L141>
+        // See <https://sig.eth.samczsun.com/>
+        // HACK: There's really no good way to parse these errors
+        let error = result.to_string();
+        if error.contains("0x09bde339") {
+            return Ok(());
+        }
+        if error.contains("0x504570e3") {
+            return Err(anyhow!("Invalid root"));
+        }
+        Err(anyhow!("Error verifiying root: {}", result))
+    }
+
+    fn fetch_events(&self, starting_block: u64, end_block: Option<u64>) -> Option<EventStream<'_>> {
+        // Start the MemberAdded event stream.
+        let mut filter = self.abi.member_added_filter().from_block(starting_block);
+        if let Some(end_block) = end_block {
+            filter = filter.to_block(end_block);
+        }
+        let stream = self
+            .ethereum
+            .fetch_events::<MemberAddedEvent>(&filter.filter)
+            .try_filter(|event| future::ready(event.event.group_id == self.group_id));
+        Some(Box::pin(stream))
+    }
+}

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -1,228 +1,113 @@
-mod abi;
+//! Functionality for interacting with smart contracts deployed on chain.
+pub mod batching;
 pub mod confirmed_log_query;
+pub mod legacy;
 
-use self::abi::{MemberAddedFilter, SemaphoreContract as Semaphore};
 use crate::{
-    ethereum::{Ethereum, EventError, Log, ProviderStack, TxError},
-    tx_sitter::Sitter,
+    contracts::legacy::MemberAddedEvent,
+    ethereum::{Ethereum, EventError, Log, TxError},
 };
-use anyhow::{anyhow, Result as AnyhowResult};
+use async_trait::async_trait;
 use clap::Parser;
-use core::future;
 use ethers::{
-    providers::Middleware,
-    types::{Address, TransactionReceipt, U256},
+    prelude::{Address, U256},
+    types::TransactionReceipt,
 };
-use futures::{Stream, TryStreamExt};
+use futures::Stream;
 use semaphore::Field;
-use tracing::{error, info, instrument};
+use std::{pin::Pin, sync::Arc};
 
-pub type MemberAddedEvent = MemberAddedFilter;
-
+/// Configuration options for the component responsible for interacting with the
+/// contract.
 #[derive(Clone, Debug, PartialEq, Eq, Parser)]
 #[group(skip)]
 pub struct Options {
-    /// Semaphore contract address.
+    /// The address of the identity manager contract.
     #[clap(long, env, default_value = "174ee9b5fBb5Eb68B6C61032946486dD9c2Dc4b6")]
-    pub semaphore_address: Address,
+    pub identity_manager_address: Address,
 
-    /// The Semaphore group id to use
+    // TODO This option should be removed.
+    /// The semaphore group identifier to use.
     #[clap(long, env, default_value = "1")]
     pub group_id: U256,
 
+    // TODO This option should be removed.
     /// When set, it will create the group if it does not exist with the given
     /// depth.
     #[clap(long, env)]
     pub create_group_depth: Option<usize>,
 
     /// Initial value of the Merkle tree leaves. Defaults to the initial value
-    /// in Semaphore.sol.
+    /// in the identity manager contract.
     #[clap(
         long,
         env,
         default_value = "0000000000000000000000000000000000000000000000000000000000000000"
     )]
-    pub initial_leaf: Field,
+    pub initial_leaf_value: Field,
 }
 
-pub struct Contracts {
-    ethereum:     Ethereum,
-    sitter:       Sitter,
-    semaphore:    Semaphore<ProviderStack>,
-    group_id:     U256,
-    tree_depth:   usize,
-    initial_leaf: Field,
-}
+/// A trait representing an identity manager that is able to submit user
+/// identities to a contract located on the blockchain.
+#[async_trait]
+pub trait IdentityManager {
+    /// Create and configure a new instance of the identity manager.
+    ///
+    /// # Arguments
+    ///
+    /// - `options`: The options used to configure the identity manager.
+    /// - `ethereum`: A connector for an ethereum-compatible blockchain.
+    async fn new(options: Options, ethereum: Ethereum) -> anyhow::Result<Self>
+    where
+        Self: Sized;
 
-impl Contracts {
-    #[instrument(level = "debug", skip_all)]
-    pub async fn new(options: Options, ethereum: Ethereum) -> AnyhowResult<Self> {
-        // Sanity check the group id
-        if options.group_id == U256::zero() {
-            error!(group_id = ?options.group_id, "Invalid group id: must be greater than zero");
-            return Err(anyhow!("group id must be non-zero"));
-        }
+    /// Returns the depth of the merkle tree managed by this `IdentityManager`.
+    fn tree_depth(&self) -> usize;
 
-        // Sanity check the address
-        // TODO: Check that the contract is actually a Semaphore by matching bytecode.
-        let address = options.semaphore_address;
-        let code = ethereum.provider().get_code(address, None).await?;
-        if code.as_ref().is_empty() {
-            error!(
-                ?address,
-                "No contract code deployed at provided Semaphore address"
-            );
-            return Err(anyhow!("Invalid Semaphore address"));
-        }
+    /// Returns the value used for a newly initialized merkle tree leaf.
+    fn initial_leaf_value(&self) -> Field;
 
-        // Connect to Contract
-        let semaphore = Semaphore::new(options.semaphore_address, ethereum.provider().clone());
+    /// Returns the group identifier associated with the identity manager.
+    fn group_id(&self) -> U256;
 
-        // Test contract by calling a view function and make sure we are manager.
-        let manager = semaphore.manager().call().await?;
-        if manager != ethereum.address() {
-            error!(?manager, signer = ?ethereum.address(), "Signer is not the manager of the Semaphore contract");
-            // return Err(anyhow!("Signer is not manager"));
-            // TODO: If not manager, proceed in read-only mode.
-        }
-        info!(?address, ?manager, "Connected to Semaphore contract");
+    /// Returns the number of the latest block that is confirmed to have been
+    /// mined.
+    async fn confirmed_block_number(&self) -> Result<u64, EventError>;
 
-        let sitter = Sitter::new(ethereum.clone()).await?;
+    /// Returns `true` if this `IdentityManager` acts via the manager address of
+    /// the on-chain contract it manages.
+    async fn is_owner(&self) -> anyhow::Result<bool>;
 
-        // Make sure the group exists.
-        let existing_tree_depth = semaphore.get_depth(options.group_id).call().await?;
-        let actual_tree_depth = if existing_tree_depth == 0 {
-            if let Some(new_depth) = options.create_group_depth {
-                info!(
-                    "Group {} not found, creating it with depth {}",
-                    options.group_id, new_depth
-                );
-                let tx = semaphore
-                    .create_group(
-                        options.group_id,
-                        new_depth.try_into()?,
-                        options.initial_leaf.to_be_bytes().into(),
-                    )
-                    .tx;
-                sitter.send(tx).await?;
-                new_depth
-            } else {
-                error!(group_id = ?options.group_id, "Group does not exist");
-                return Err(anyhow!("Group does not exist"));
-            }
-        } else {
-            info!(group_id = ?options.group_id, ?existing_tree_depth, "Semaphore group found.");
-            usize::from(existing_tree_depth)
-        };
-
-        // TODO: Some way to check the initial leaf
-
-        Ok(Self {
-            ethereum,
-            sitter,
-            semaphore,
-            group_id: options.group_id,
-            tree_depth: actual_tree_depth,
-            initial_leaf: options.initial_leaf,
-        })
-    }
-
-    #[must_use]
-    pub const fn group_id(&self) -> U256 {
-        self.group_id
-    }
-
-    #[must_use]
-    pub const fn tree_depth(&self) -> usize {
-        self.tree_depth
-    }
-
-    #[must_use]
-    pub const fn initial_leaf(&self) -> Field {
-        self.initial_leaf
-    }
-
-    pub async fn confirmed_block_number(&self) -> Result<u64, EventError> {
-        self.ethereum
-            .confirmed_block_number()
-            .await
-            .map(|num| num.as_u64())
-    }
-
-    #[allow(clippy::disallowed_methods)] // False positive from macro expansion.
-    #[instrument(level = "debug", skip(self))]
-    pub fn fetch_events(
+    /// Registers the provided `identity_commitments` with the contract on
+    /// chain.
+    async fn register_identities(
         &self,
-        starting_block: u64,
-        end_block: Option<u64>,
-    ) -> impl Stream<Item = Result<Log<MemberAddedEvent>, EventError>> + '_ {
-        // Start MemberAdded log event stream
-        let mut filter = self
-            .semaphore
-            .member_added_filter()
-            .from_block(starting_block);
+        identity_commitments: Vec<Field>,
+    ) -> Result<TransactionReceipt, TxError>;
 
-        if let Some(end_block) = end_block {
-            filter = filter.to_block(end_block);
-        }
-        self.ethereum
-            .fetch_events::<MemberAddedEvent>(&filter.filter)
-            .try_filter(|event| future::ready(event.event.group_id == self.group_id))
-    }
+    /// Asserts that the provided `root` is the current root held by the
+    /// contract on the chain.
+    async fn assert_latest_root(&self, root: Field) -> anyhow::Result<()>;
 
-    #[instrument(level = "debug", skip_all)]
-    #[allow(dead_code)]
-    pub async fn is_manager(&self) -> AnyhowResult<bool> {
-        info!(address = ?self.ethereum.address(), "My address");
-        let manager = self.semaphore.manager().call().await?;
-        info!(?manager, "Fetched manager address");
-        Ok(manager == self.ethereum.address())
-    }
+    /// Asserts that the provided `root` is a valid root.
+    ///
+    /// A valid root is one that has not expired based on the time since it was
+    /// inserted into the history of roots on chain.
+    async fn assert_valid_root(&self, root: Field) -> anyhow::Result<()>;
 
-    #[instrument(level = "debug", skip_all)]
-    pub async fn insert_identity(&self, commitment: Field) -> Result<TransactionReceipt, TxError> {
-        info!(%commitment, "Inserting identity in contract");
-
-        // Send create tx
-        let commitment = U256::from(commitment.to_be_bytes());
-        let receipt = self
-            .sitter
-            .send(self.semaphore.add_member(self.group_id, commitment).tx)
-            .await?;
-        Ok(receipt)
-    }
-
-    // TODO: Ideally we'd have a `get_root` function, but the contract doesn't
-    // support this.
-    #[instrument(level = "debug", skip_all)]
-    pub async fn assert_valid_root(&self, root: Field) -> AnyhowResult<()> {
-        // HACK: Abuse the `verifyProof` function.
-
-        let result = self
-            .semaphore
-            .verify_proof(
-                root.to_be_bytes().into(),
-                self.group_id,
-                U256::zero(),
-                U256::zero(),
-                U256::zero(),
-                [U256::zero(); 8],
-            )
-            .call()
-            .await
-            .expect_err("Proof is invalid");
-        // Result will be either `0x09bde339`: `InvalidProof()` (good) or
-        // `0x504570e3`: `InvalidRoot()` (bad).
-        // See <https://github.com/worldcoin/world-id-example-airdrop/blob/03de53d2cb016ddef28b26e8237e85b62ec385c7/src/Semaphore.sol#L141>
-        // See <https://sig.eth.samczsun.com/>
-        // HACK: There's really no good way to parse these errors
-        let error = result.to_string();
-        if error.contains("0x09bde339") {
-            return Ok(());
-        }
-        if error.contains("0x504570e3") {
-            return Err(anyhow!("Invalid root"));
-        }
-        Err(anyhow!("Error verifiying root: {}", result))
-    }
+    // TODO [Ara] Remove this once the OZ relay work is integrated.
+    /// Fetches member added events from the blockchain from a starting block to
+    /// an optionally specified end block.
+    ///
+    /// Such functionality need not be supported by all identity managers, and
+    /// these may return `None` to signify such a situation.
+    fn fetch_events(&self, starting_block: u64, end_block: Option<u64>) -> Option<EventStream>;
 }
+
+/// The type of the event stream used by the contracts to receive events from on
+/// chain.
+type EventStream<'a> =
+    Pin<Box<dyn Stream<Item = Result<Log<MemberAddedEvent>, EventError>> + Send + 'a>>;
+
+/// A type for an identity manager object that can be sent across threads.
+pub type SharedIdentityManager = Arc<dyn IdentityManager + Send + Sync>;

--- a/src/ethereum_subscriber.rs
+++ b/src/ethereum_subscriber.rs
@@ -1,5 +1,5 @@
 use crate::{
-    contracts::{Contracts, MemberAddedEvent},
+    contracts::{legacy::MemberAddedEvent, SharedIdentityManager},
     database::{
         ConfirmedIdentityEvent, Database, Error as DatabaseError, IdentityConfirmationResult,
     },
@@ -7,7 +7,7 @@ use crate::{
     identity_committer::IdentityCommitter,
     identity_tree::{SharedTreeState, TreeState},
 };
-use futures::{StreamExt, TryStreamExt};
+use futures::TryStreamExt;
 use semaphore::Field;
 use std::{cmp::min, sync::Arc, time::Duration};
 use thiserror::Error;
@@ -30,7 +30,7 @@ pub struct EthereumSubscriber {
     instance:           RwLock<Option<RunningInstance>>,
     starting_block:     u64,
     database:           Arc<Database>,
-    contracts:          Arc<Contracts>,
+    identity_manager:   SharedIdentityManager,
     tree_state:         SharedTreeState,
     identity_committer: Arc<IdentityCommitter>,
 }
@@ -39,7 +39,7 @@ impl EthereumSubscriber {
     pub fn new(
         starting_block: u64,
         database: Arc<Database>,
-        contracts: Arc<Contracts>,
+        identity_manager: SharedIdentityManager,
         tree_state: SharedTreeState,
         identity_committer: Arc<IdentityCommitter>,
     ) -> Self {
@@ -47,7 +47,7 @@ impl EthereumSubscriber {
             instance: RwLock::new(None),
             starting_block,
             database,
-            contracts,
+            identity_manager,
             tree_state,
             identity_committer,
         }
@@ -64,7 +64,7 @@ impl EthereumSubscriber {
         let mut starting_block = self.starting_block;
         let database = self.database.clone();
         let tree_state = self.tree_state.clone();
-        let contracts = self.contracts.clone();
+        let identity_manager = self.identity_manager.clone();
         let identity_committer = self.identity_committer.clone();
 
         let handle = tokio::spawn(async move {
@@ -74,7 +74,7 @@ impl EthereumSubscriber {
                 let processed_block = Self::process_events_internal(
                     starting_block,
                     tree_state.clone(),
-                    contracts.clone(),
+                    identity_manager.clone(),
                     database.clone(),
                     identity_committer.clone(),
                 )
@@ -93,7 +93,7 @@ impl EthereumSubscriber {
     #[instrument(level = "info", skip_all)]
     pub async fn process_initial_events(&mut self) -> Result<(), Error> {
         let end_block = self
-            .contracts
+            .identity_manager
             .confirmed_block_number()
             .await
             .map_err(Error::Event)?;
@@ -109,7 +109,7 @@ impl EthereumSubscriber {
             last_db_block + 1,
             end_block,
             self.tree_state.clone(),
-            self.contracts.clone(),
+            self.identity_manager.clone(),
             self.database.clone(),
             self.identity_committer.clone(),
         )
@@ -121,11 +121,11 @@ impl EthereumSubscriber {
     async fn process_events_internal(
         start_block: u64,
         tree_state: SharedTreeState,
-        contracts: Arc<Contracts>,
+        identity_manager: SharedIdentityManager,
         database: Arc<Database>,
         identity_committer: Arc<IdentityCommitter>,
     ) -> Result<u64, Error> {
-        let end_block = contracts
+        let end_block = identity_manager
             .confirmed_block_number()
             .await
             .map_err(Error::Event)?;
@@ -134,7 +134,7 @@ impl EthereumSubscriber {
             start_block,
             end_block,
             tree_state,
-            contracts,
+            identity_manager,
             database,
             identity_committer,
         )
@@ -194,7 +194,7 @@ impl EthereumSubscriber {
         start_block: u64,
         end_block: u64,
         tree_state: SharedTreeState,
-        contracts: Arc<Contracts>,
+        identity_manager: SharedIdentityManager,
         database: Arc<Database>,
         identity_committer: Arc<IdentityCommitter>,
     ) -> Result<u64, Error> {
@@ -207,7 +207,9 @@ impl EthereumSubscriber {
             end_block, "processing blockchain events in ethereum subscriber"
         );
 
-        let mut events = contracts.fetch_events(start_block, Some(end_block)).boxed();
+        let mut events = identity_manager
+            .fetch_events(start_block, Some(end_block))
+            .unwrap();
 
         let mut tree = tree_state.write().await.unwrap_or_else(|e| {
             error!(?e, "Failed to obtain tree lock in process_events.");
@@ -216,6 +218,7 @@ impl EthereumSubscriber {
 
         let mut wake_up_committer = false;
 
+        #[allow(clippy::manual_let_else)]
         loop {
             let event = match events.try_next().await.map_err(Error::Event)? {
                 Some(a) => a,
@@ -226,7 +229,7 @@ impl EthereumSubscriber {
 
             Self::log_event_errors(
                 &tree,
-                &contracts.initial_leaf(),
+                &identity_manager.initial_leaf_value(),
                 tree.next_leaf,
                 &identity.leaf,
             )?;
@@ -253,7 +256,10 @@ impl EthereumSubscriber {
                 .confirm_identity_and_retrigger_stale_recods(&identity.leaf)
                 .await
                 .map_err(Error::Database)?;
-            if let IdentityConfirmationResult::RetriggerProcessing = queue_status {
+            if matches!(
+                queue_status,
+                IdentityConfirmationResult::RetriggerProcessing
+            ) {
                 wake_up_committer = true;
             }
         }
@@ -310,11 +316,11 @@ impl EthereumSubscriber {
             error!(?e, "Failed to obtain tree lock in check_leaves.");
             panic!("Sequencer potentially deadlocked, terminating.");
         });
-        let initial_leaf = self.contracts.initial_leaf();
+        let initial_leaf = self.identity_manager.initial_leaf_value();
 
         if tree.next_leaf > 0 {
             if let Err(error) = self
-                .contracts
+                .identity_manager
                 .assert_valid_root(tree.merkle_tree.root())
                 .await
             {

--- a/src/identity_committer.rs
+++ b/src/identity_committer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    contracts::Contracts,
+    contracts::{IdentityManager, SharedIdentityManager},
     database::Database,
     identity_tree::{Hash, SharedTreeState},
     utils::spawn_or_abort,
@@ -60,22 +60,22 @@ impl RunningInstance {
 /// a time. Spawning multiple worker threads will result in undefined behavior,
 /// including data duplication.
 pub struct IdentityCommitter {
-    instance:   RwLock<Option<RunningInstance>>,
-    database:   Arc<Database>,
-    contracts:  Arc<Contracts>,
-    tree_state: SharedTreeState,
+    instance:         RwLock<Option<RunningInstance>>,
+    database:         Arc<Database>,
+    identity_manager: SharedIdentityManager,
+    tree_state:       SharedTreeState,
 }
 
 impl IdentityCommitter {
     pub fn new(
         database: Arc<Database>,
-        contracts: Arc<Contracts>,
+        contracts: SharedIdentityManager,
         tree_state: SharedTreeState,
     ) -> Self {
         Self {
             instance: RwLock::new(None),
             database,
-            contracts,
+            identity_manager: contracts,
             tree_state,
         }
     }
@@ -90,7 +90,7 @@ impl IdentityCommitter {
         let (shutdown_sender, mut shutdown_receiver) = mpsc::channel(1);
         let (wake_up_sender, mut wake_up_receiver) = mpsc::channel(1);
         let database = self.database.clone();
-        let contracts = self.contracts.clone();
+        let identity_manager = self.identity_manager.clone();
         let tree_state = self.tree_state.clone();
         let handle = spawn_or_abort(async move {
             loop {
@@ -102,8 +102,14 @@ impl IdentityCommitter {
                         return Ok(());
                     }
 
-                    Self::commit_identity(&database, &contracts, &tree_state, group_id, commitment)
-                        .await?;
+                    Self::commit_identity(
+                        &database,
+                        &*identity_manager,
+                        &tree_state,
+                        group_id,
+                        commitment,
+                    )
+                    .await?;
                 }
 
                 select! {
@@ -127,7 +133,7 @@ impl IdentityCommitter {
     #[instrument(level = "info", skip_all)]
     async fn commit_identity(
         database: &Database,
-        contracts: &Contracts,
+        identity_manager: &(dyn IdentityManager + Send + Sync),
         tree_state: &SharedTreeState,
         group_id: usize,
         commitment: Hash,
@@ -151,10 +157,13 @@ impl IdentityCommitter {
         }
 
         // Send Semaphore transaction
-        let receipt = contracts.insert_identity(commitment).await.map_err(|e| {
-            error!(?e, "Failed to insert identity to contract.");
-            e
-        })?;
+        let receipt = identity_manager
+            .register_identities(vec![commitment])
+            .await
+            .map_err(|e| {
+                error!(?e, "Failed to insert identity to contract.");
+                e
+            })?;
 
         let block = receipt
             .block_number

--- a/tests/integration-tests.rs
+++ b/tests/integration-tests.rs
@@ -51,7 +51,7 @@ async fn simulate_eth_reorg() {
 
     options.app.ethereum.ethereum_provider =
         Url::parse(&chain.endpoint()).expect("Failed to parse ganache endpoint");
-    options.app.contracts.semaphore_address = semaphore_address;
+    options.app.contracts.identity_manager_address = semaphore_address;
     options.app.ethereum.signing_key = private_key;
     options.app.ethereum.confirmation_blocks_delay = 5;
     options.app.ethereum.refresh_rate = Duration::from_secs(1);
@@ -61,7 +61,7 @@ async fn simulate_eth_reorg() {
         .expect("Failed to spawn app.");
 
     let uri = "http://".to_owned() + &local_addr.to_string();
-    let mut ref_tree = PoseidonTree::new(22, options.app.contracts.initial_leaf);
+    let mut ref_tree = PoseidonTree::new(22, options.app.contracts.initial_leaf_value);
     let client = Client::new();
 
     let provider = Provider::<Http>::try_from(chain.endpoint())
@@ -146,7 +146,7 @@ async fn insert_identity_and_proofs() {
 
     options.app.ethereum.ethereum_provider =
         Url::parse(&chain.endpoint()).expect("Failed to parse ganache endpoint");
-    options.app.contracts.semaphore_address = semaphore_address;
+    options.app.contracts.identity_manager_address = semaphore_address;
     options.app.ethereum.signing_key = private_key;
     options.app.ethereum.confirmation_blocks_delay = 2;
     options.app.ethereum.refresh_rate = Duration::from_secs(1);
@@ -156,14 +156,14 @@ async fn insert_identity_and_proofs() {
         .expect("Failed to spawn app.");
 
     let uri = "http://".to_owned() + &local_addr.to_string();
-    let mut ref_tree = PoseidonTree::new(22, options.app.contracts.initial_leaf);
+    let mut ref_tree = PoseidonTree::new(22, options.app.contracts.initial_leaf_value);
     let client = Client::new();
     test_inclusion_proof(
         &uri,
         &client,
         0,
         &mut ref_tree,
-        &options.app.contracts.initial_leaf,
+        &options.app.contracts.initial_leaf_value,
         true,
     )
     .await;
@@ -172,7 +172,7 @@ async fn insert_identity_and_proofs() {
         &client,
         1,
         &mut ref_tree,
-        &options.app.contracts.initial_leaf,
+        &options.app.contracts.initial_leaf_value,
         true,
     )
     .await;
@@ -201,7 +201,7 @@ async fn insert_identity_and_proofs() {
         &client,
         2,
         &mut ref_tree,
-        &options.app.contracts.initial_leaf,
+        &options.app.contracts.initial_leaf_value,
         true,
     )
     .await;


### PR DESCRIPTION
This PR refactors how the existing legacy contract is handled by introducing a trait to unify behaviour between the two contracts. This is in preparation for introducing the batching contract to the codebase with the swap between the two controlled by a cargo feature.

There are no functional changes in this PR, but it does make some renames around the codebase to make things clearer now that "semaphore" is not the only contract. To that end, it intentionally does not test what little integration of the batching prover there is.