### PR TITLE
Avoid building and testing with all features on CI

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -95,12 +95,12 @@ jobs:
       # have it just print `--help`.
       - name: Build tests
         run: |
-          cargo test --locked --all-features --all-targets --no-run
-          cargo test --locked --all-features --doc -- --help
+          cargo test --locked --features "bench, mimalloc" --all-targets --no-run
+          cargo test --locked --features "bench, mimalloc" --doc -- --help
       - name: Run tests
         run: |
-          cargo test --locked --all-features --all-targets -- --nocapture
-          cargo test --locked --all-features --doc -- --nocapture
+          cargo test --locked --features "bench, mimalloc" --all-targets -- --nocapture
+          cargo test --locked --features "bench, mimalloc" --doc -- --nocapture
 
   codecov:
     # See <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/source-based-code-coverage.html>
@@ -134,12 +134,12 @@ jobs:
           version: nightly
       - name: Build tests with coverage
         run: |
-          cargo test --locked --all-features --all-targets --no-fail-fast --no-run
-          cargo test --locked --all-features --doc --no-fail-fast -- --help
+          cargo test --locked --features "bench, mimalloc" --all-targets --no-fail-fast --no-run
+          cargo test --locked --features "bench, mimalloc" --doc --no-fail-fast -- --help
       - name: Run tests with coverage
         run: |
-          cargo test --locked --all-features --all-targets --no-fail-fast -- --nocapture
-          cargo test --locked --all-features --doc --no-fail-fast
+          cargo test --locked --features "bench, mimalloc" --all-targets --no-fail-fast -- --nocapture
+          cargo test --locked --features "bench, mimalloc" --doc --no-fail-fast
       - name: Merge execution traces
         run: cargo profdata -- merge -sparse $(find . -iname "profile-*.profraw") -o profile.profdata
       - name: Export to lcov format for codecov


### PR DESCRIPTION
This doesn't work now that we have a feature that switches between the legacy and batching contracts.