### PR TITLE
fix: set DD_SERVICE env

### DIFF
--- a/deploy/templates/statefulset.yaml
+++ b/deploy/templates/statefulset.yaml
@@ -80,6 +80,8 @@ spec:
                 secretKeyRef:
                   name: application
                   key: DATABASE_URL
+            - name: DD_SERVICE
+              value: {{ .Release.Name }}
             - name: TRACE_OTLP
               value: "grpc://$(HOST_IP):4317"
             - name: TRACE_RESOURCE_ENV


### PR DESCRIPTION
We need to set an explicit name for the service because, without this env datadog tries to guess it and now uses its chart name. It was ok when we had only one deployment. Now, we have more than one, and we should be able to split those logs/metrics with the service field.