### PR TITLE
Poll oz transactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ ethers = { version = "1.0.0", features = [ "ws", "ipc", "openssl", "abigen" ] }
 eyre = "0.6"
 futures = "0.3"
 futures-util = { version = "^0.3" }
+hex = "0.4.3"
 hyper = { version = "^0.14.17", features = ["server", "tcp", "http1", "http2"] }
 once_cell = "1.8"
 prometheus = "0.13.3" # We need upstream PR#465 to fix #272.

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -186,6 +186,11 @@ impl IdentityManager {
             .map_err(|tx_err| anyhow!("{}", tx_err.to_string()))
     }
 
+    pub async fn mine_identities(&self, transaction_id: TransactionId) -> anyhow::Result<()> {
+        self.ethereum.mine_transaction(transaction_id).await?;
+        Ok(())
+    }
+
     #[instrument(level = "debug", skip_all)]
     pub async fn assert_latest_root(&self, root: Field) -> anyhow::Result<()> {
         let latest_root = self.abi.latest_root().call().await?;

--- a/src/ethereum/mod.rs
+++ b/src/ethereum/mod.rs
@@ -73,4 +73,8 @@ impl Ethereum {
     ) -> Result<TransactionId, TxError> {
         self.write_provider.send_transaction(tx, only_once).await
     }
+
+    pub async fn mine_transaction(&self, tx: TransactionId) -> Result<(), TxError> {
+        self.write_provider.mine_transaction(tx).await
+    }
 }

--- a/src/ethereum/write/mod.rs
+++ b/src/ethereum/write/mod.rs
@@ -38,6 +38,9 @@ pub enum TxError {
 
     #[error("Transaction failed: {0:?}.")]
     Failed(Option<TransactionReceipt>),
+
+    #[error("Error parsing transaction id: {0}")]
+    Parse(Box<dyn Error + Send + Sync + 'static>),
 }
 
 #[allow(clippy::module_name_repetitions)]

--- a/src/ethereum/write/mod.rs
+++ b/src/ethereum/write/mod.rs
@@ -21,6 +21,9 @@ pub enum TxError {
     #[error("Error filling transaction: {0}")]
     Fill(Box<dyn Error + Send + Sync + 'static>),
 
+    #[error("Error fetching transaction from the blockchain: {0}")]
+    Fetch(Box<dyn Error + Send + Sync + 'static>),
+
     #[error("Timeout while sending transaction")]
     SendTimeout,
 

--- a/src/ethereum/write/mod.rs
+++ b/src/ethereum/write/mod.rs
@@ -1,9 +1,10 @@
+use std::{error::Error, fmt::Debug};
+
 use async_trait::async_trait;
 use ethers::{
     providers::ProviderError,
     types::{transaction::eip2718::TypedTransaction, Address, TransactionReceipt, H256},
 };
-use std::{error::Error, fmt::Debug};
 use thiserror::Error;
 
 #[derive(Clone, Debug)]
@@ -47,6 +48,8 @@ pub trait WriteProvider: Sync + Send + Debug {
         tx: TypedTransaction,
         only_once: bool,
     ) -> Result<TransactionId, TxError>;
+
+    async fn mine_transaction(&self, tx: TransactionId) -> Result<(), TxError>;
 
     fn address(&self) -> Address;
 }

--- a/src/ethereum/write_dev/mod.rs
+++ b/src/ethereum/write_dev/mod.rs
@@ -27,7 +27,7 @@ use prometheus::{
 };
 use reqwest::Client as ReqwestClient;
 use tokio::time::timeout;
-use tracing::{debug_span, error, info, info_span, instrument, Instrument};
+use tracing::{debug_span, error, info, info_span, instrument, warn, Instrument};
 
 use self::{estimator::Estimator, gas_oracle_logger::GasOracleLogger, min_gas_fees::MinGasFees};
 use super::{
@@ -141,73 +141,7 @@ impl WriteProvider for Provider {
     }
 
     async fn mine_transaction(&self, tx: TransactionId) -> Result<(), TxError> {
-        let tx_hash =
-            tx.0.parse::<TxHash>()
-                .map_err(|err| TxError::Parse(Box::new(err)))?;
-
-        let pending = PendingTransaction::new(tx_hash, self.inner.provider());
-
-        let timer = TX_LATENCY.start_timer();
-
-        let receipt = timeout(self.mine_timeout, pending)
-            .instrument(info_span!("Wait for TX to be mined"))
-            .await
-            .map_err(|elapsed| {
-                error!(?elapsed, "Waiting for transaction confirmation timed out");
-                TxError::ConfirmationTimeout
-            })?
-            .map_err(|err| {
-                error!(?tx_hash, ?err, "Transaction failed to confirm");
-
-                TxError::Confirmation(err)
-            })?
-            .ok_or_else(|| {
-                error!(?tx_hash, "Transaction dropped");
-                TxError::Dropped(tx_hash)
-            })?;
-
-        timer.observe_duration();
-        info!(?tx_hash, ?receipt, "Transaction mined");
-
-        if let Some(gas_price) = receipt.effective_gas_price {
-            TX_GAS_PRICE.set(gas_price.as_u128() as f64);
-        } else {
-            error!(
-                ?tx,
-                ?receipt,
-                "Receipt did not include effective gas price."
-            );
-        }
-
-        if let Some(gas_used) = receipt.gas_used {
-            TX_GAS_USED.inc_by(gas_used.as_u128() as f64);
-            // TODO: Bring back gas observations
-            // if let Some(gas_limit) = tx.gas() {
-            //     let gas_fraction = gas_used.as_u128() as f64 / gas_limit.as_u128() as
-            // f64;     TX_GAS_FRACTION.observe(gas_fraction);
-            //     if gas_fraction > 0.9 {
-            //         warn!(
-            //             %gas_used,
-            //             %gas_limit,
-            //             %gas_fraction,
-            //             "Transaction used more than 90% of the gas limit."
-            //         );
-            //     }
-            // }
-            if let Some(gas_price) = receipt.effective_gas_price {
-                let cost_wei = gas_used * gas_price;
-                TX_WEI_USED.inc_by(cost_wei.as_u128() as f64);
-            }
-        } else {
-            error!(?tx, ?receipt, "Receipt did not include gas used.");
-        }
-
-        // Check receipt status for success
-        if receipt.status != Some(U64::from(1_u64)) {
-            return Err(TxError::Failed(Some(receipt)));
-        }
-
-        Ok(())
+        self.mine_transaction(tx).await
     }
 
     fn address(&self) -> Address {
@@ -344,6 +278,94 @@ impl Provider {
         })
     }
 
+    #[instrument(level = "debug", skip_all)]
+    async fn mine_transaction(&self, tx: TransactionId) -> Result<(), TxError> {
+        let tx_hash = hex::decode(&tx.0).map_err(|err| TxError::Parse(Box::new(err)))?;
+
+        let tx_hash = TxHash::from_slice(&tx_hash);
+
+        // We're fetching the transaction again to get the nonce and gas limit
+        // TODO: We should be able to transfer this data via the input args
+        let tx = self
+            .inner
+            .get_transaction(tx_hash)
+            .await
+            .map_err(|err| TxError::Fetch(Box::new(err)))?
+            .ok_or_else(|| {
+                error!(?tx_hash, "Transaction dropped");
+                TxError::Dropped(tx_hash)
+            })?;
+
+        let nonce = tx.nonce;
+
+        let pending = PendingTransaction::new(tx_hash, self.inner.provider());
+
+        let timer = TX_LATENCY.start_timer();
+
+        let receipt = timeout(self.mine_timeout, pending)
+            .instrument(info_span!("Wait for TX to be mined"))
+            .await
+            .map_err(|elapsed| {
+                error!(?elapsed, "Waiting for transaction confirmation timed out");
+                TxError::ConfirmationTimeout
+            })?
+            .map_err(|err| {
+                error!(?nonce, ?tx_hash, ?err, "Transaction failed to confirm");
+
+                TxError::Confirmation(err)
+            })?
+            .ok_or_else(|| {
+                error!(?nonce, ?tx_hash, "Transaction dropped");
+                TxError::Dropped(tx_hash)
+            })?;
+
+        timer.observe_duration();
+        info!(?nonce, ?tx_hash, ?receipt, "Transaction mined");
+
+        if let Some(gas_price) = receipt.effective_gas_price {
+            TX_GAS_PRICE.set(gas_price.as_u128() as f64);
+        } else {
+            error!(
+                ?nonce,
+                ?tx,
+                ?receipt,
+                "Receipt did not include effective gas price."
+            );
+        }
+
+        if let Some(gas_used) = receipt.gas_used {
+            TX_GAS_USED.inc_by(gas_used.as_u128() as f64);
+            let gas_limit = tx.gas;
+            let gas_fraction = gas_used.as_u128() as f64 / gas_limit.as_u128() as f64;
+
+            TX_GAS_FRACTION.observe(gas_fraction);
+
+            if gas_fraction > 0.9 {
+                warn!(
+                    ?nonce,
+                    %gas_used,
+                    %gas_limit,
+                    %gas_fraction,
+                    "Transaction used more than 90% of the gas limit."
+                );
+            }
+
+            if let Some(gas_price) = receipt.effective_gas_price {
+                let cost_wei = gas_used * gas_price;
+                TX_WEI_USED.inc_by(cost_wei.as_u128() as f64);
+            }
+        } else {
+            error!(?nonce, ?tx, ?receipt, "Receipt did not include gas used.");
+        }
+
+        // Check receipt status for success
+        if receipt.status != Some(U64::from(1_u64)) {
+            return Err(TxError::Failed(Some(receipt)));
+        }
+
+        Ok(())
+    }
+
     #[instrument(level = "info", skip(self))]
     #[allow(clippy::option_if_let_else)] // Less readable
     #[allow(clippy::cast_precision_loss)]
@@ -406,7 +428,7 @@ impl Provider {
 
         info!(?nonce, ?tx_hash, "Transaction in mempool");
 
-        let transaction_id = tx_hash.to_string();
+        let transaction_id = hex::encode(tx_hash.as_bytes());
 
         Ok(TransactionId(transaction_id))
     }

--- a/src/ethereum/write_dev/mod.rs
+++ b/src/ethereum/write_dev/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::option_if_let_else, clippy::cast_precision_loss)]
+
 use std::{sync::Arc, time::Duration};
 
 use anyhow::{anyhow, Result as AnyhowResult};
@@ -367,8 +369,6 @@ impl Provider {
     }
 
     #[instrument(level = "info", skip(self))]
-    #[allow(clippy::option_if_let_else)] // Less readable
-    #[allow(clippy::cast_precision_loss)]
     async fn send_transaction_unlogged(
         &self,
         tx: TypedTransaction,

--- a/src/ethereum/write_dev/mod.rs
+++ b/src/ethereum/write_dev/mod.rs
@@ -27,7 +27,7 @@ use prometheus::{
 };
 use reqwest::Client as ReqwestClient;
 use tokio::time::timeout;
-use tracing::{debug_span, error, info, info_span, instrument, warn, Instrument};
+use tracing::{debug_span, error, info, info_span, instrument, Instrument};
 
 use self::{estimator::Estimator, gas_oracle_logger::GasOracleLogger, min_gas_fees::MinGasFees};
 use super::{

--- a/src/ethereum/write_dev/mod.rs
+++ b/src/ethereum/write_dev/mod.rs
@@ -12,11 +12,11 @@ use ethers::{
         },
         SignerMiddleware,
     },
-    providers::Middleware,
+    providers::{Middleware, PendingTransaction},
     signers::{LocalWallet, Signer, Wallet},
     types::{
         transaction::eip2718::TypedTransaction, u256_from_f64_saturating, Address, BlockId,
-        BlockNumber, Chain, H256, U64,
+        BlockNumber, Chain, TxHash, H256, U64,
     },
 };
 use futures::try_join;
@@ -141,7 +141,73 @@ impl WriteProvider for Provider {
     }
 
     async fn mine_transaction(&self, tx: TransactionId) -> Result<(), TxError> {
-        todo!()
+        let tx_hash =
+            tx.0.parse::<TxHash>()
+                .map_err(|err| TxError::Parse(Box::new(err)))?;
+
+        let pending = PendingTransaction::new(tx_hash, self.inner.provider());
+
+        let timer = TX_LATENCY.start_timer();
+
+        let receipt = timeout(self.mine_timeout, pending)
+            .instrument(info_span!("Wait for TX to be mined"))
+            .await
+            .map_err(|elapsed| {
+                error!(?elapsed, "Waiting for transaction confirmation timed out");
+                TxError::ConfirmationTimeout
+            })?
+            .map_err(|err| {
+                error!(?tx_hash, ?err, "Transaction failed to confirm");
+
+                TxError::Confirmation(err)
+            })?
+            .ok_or_else(|| {
+                error!(?tx_hash, "Transaction dropped");
+                TxError::Dropped(tx_hash)
+            })?;
+
+        timer.observe_duration();
+        info!(?tx_hash, ?receipt, "Transaction mined");
+
+        if let Some(gas_price) = receipt.effective_gas_price {
+            TX_GAS_PRICE.set(gas_price.as_u128() as f64);
+        } else {
+            error!(
+                ?tx,
+                ?receipt,
+                "Receipt did not include effective gas price."
+            );
+        }
+
+        if let Some(gas_used) = receipt.gas_used {
+            TX_GAS_USED.inc_by(gas_used.as_u128() as f64);
+            // TODO: Bring back gas observations
+            // if let Some(gas_limit) = tx.gas() {
+            //     let gas_fraction = gas_used.as_u128() as f64 / gas_limit.as_u128() as
+            // f64;     TX_GAS_FRACTION.observe(gas_fraction);
+            //     if gas_fraction > 0.9 {
+            //         warn!(
+            //             %gas_used,
+            //             %gas_limit,
+            //             %gas_fraction,
+            //             "Transaction used more than 90% of the gas limit."
+            //         );
+            //     }
+            // }
+            if let Some(gas_price) = receipt.effective_gas_price {
+                let cost_wei = gas_used * gas_price;
+                TX_WEI_USED.inc_by(cost_wei.as_u128() as f64);
+            }
+        } else {
+            error!(?tx, ?receipt, "Receipt did not include gas used.");
+        }
+
+        // Check receipt status for success
+        if receipt.status != Some(U64::from(1_u64)) {
+            return Err(TxError::Failed(Some(receipt)));
+        }
+
+        Ok(())
     }
 
     fn address(&self) -> Address {
@@ -305,6 +371,7 @@ impl Provider {
                 error!(?error, "Failed to fill transaction");
                 TxError::Fill(Box::new(error))
             })?;
+
         let nonce = tx.nonce().unwrap().as_u64();
         let gas_limit = tx.gas().unwrap().as_u128() as f64;
         let gas_price = tx.gas_price().unwrap().as_u128() as f64;
@@ -334,72 +401,12 @@ impl Provider {
             error!(?nonce, ?error, "Failed to send transaction");
             TxError::Send(Box::new(error))
         })?;
+
         let tx_hash: H256 = *pending;
 
         info!(?nonce, ?tx_hash, "Transaction in mempool");
 
-        // Wait for TX to be mined
-        let timer = TX_LATENCY.start_timer();
-
-        let receipt = timeout(self.mine_timeout, pending)
-            .instrument(info_span!("Wait for TX to be mined"))
-            .await
-            .map_err(|elapsed| {
-                error!(?elapsed, "Waiting for transaction confirmation timed out");
-                TxError::ConfirmationTimeout
-            })?
-            .map_err(|err| {
-                error!(?nonce, ?tx_hash, ?err, "Transaction failed to confirm");
-
-                TxError::Confirmation(err)
-            })?
-            .ok_or_else(|| {
-                error!(?nonce, ?tx_hash, "Transaction dropped");
-                TxError::Dropped(tx_hash)
-            })?;
-        timer.observe_duration();
-        info!(?nonce, ?tx_hash, ?receipt, "Transaction mined");
-
-        // Check receipt for gas used
-        if let Some(gas_price) = receipt.effective_gas_price {
-            TX_GAS_PRICE.set(gas_price.as_u128() as f64);
-        } else {
-            error!(
-                ?nonce,
-                ?tx,
-                ?receipt,
-                "Receipt did not include effective gas price."
-            );
-        }
-        if let Some(gas_used) = receipt.gas_used {
-            TX_GAS_USED.inc_by(gas_used.as_u128() as f64);
-            if let Some(gas_limit) = tx.gas() {
-                let gas_fraction = gas_used.as_u128() as f64 / gas_limit.as_u128() as f64;
-                TX_GAS_FRACTION.observe(gas_fraction);
-                if gas_fraction > 0.9 {
-                    warn!(
-                        ?nonce,
-                        %gas_used,
-                        %gas_limit,
-                        %gas_fraction,
-                        "Transaction used more than 90% of the gas limit."
-                    );
-                }
-            }
-            if let Some(gas_price) = receipt.effective_gas_price {
-                let cost_wei = gas_used * gas_price;
-                TX_WEI_USED.inc_by(cost_wei.as_u128() as f64);
-            }
-        } else {
-            error!(?nonce, ?tx, ?receipt, "Receipt did not include gas used.");
-        }
-
-        // Check receipt status for success
-        if receipt.status != Some(U64::from(1_u64)) {
-            return Err(TxError::Failed(Some(receipt)));
-        }
-
-        let transaction_id = receipt.transaction_hash.to_string();
+        let transaction_id = tx_hash.to_string();
 
         Ok(TransactionId(transaction_id))
     }

--- a/src/ethereum/write_oz/mod.rs
+++ b/src/ethereum/write_oz/mod.rs
@@ -69,7 +69,7 @@ impl WriteProvider for Provider {
     }
 
     async fn mine_transaction(&self, tx: TransactionId) -> Result<(), TxError> {
-        todo!()
+        self.inner.mine_transaction(tx).await
     }
 
     fn address(&self) -> Address {

--- a/src/ethereum/write_oz/mod.rs
+++ b/src/ethereum/write_oz/mod.rs
@@ -68,6 +68,10 @@ impl WriteProvider for Provider {
         self.inner.send_transaction(tx, only_once).await
     }
 
+    async fn mine_transaction(&self, tx: TransactionId) -> Result<(), TxError> {
+        todo!()
+    }
+
     fn address(&self) -> Address {
         self.address
     }

--- a/src/ethereum/write_oz/openzeppelin.rs
+++ b/src/ethereum/write_oz/openzeppelin.rs
@@ -254,8 +254,13 @@ impl OzRelay {
 
         info!(?tx_id, "Transaction submitted to OZ Relay");
 
-        self.mine_transaction_id(&tx_id).await?;
         Ok(TransactionId(tx_id))
+    }
+
+    pub async fn mine_transaction(&self, tx_id: TransactionId) -> Result<(), TxError> {
+        self.mine_transaction_id(tx_id.0.as_str()).await?;
+
+        Ok(())
     }
 
     async fn client(&self) -> Result<MutexGuard<ExpiringClient>, Error> {

--- a/src/identity_committer.rs
+++ b/src/identity_committer.rs
@@ -440,8 +440,8 @@ impl IdentityCommitter {
 
         // The transaction will be awaited on asynchronously
         permit.send(PendingIdentities {
-            transaction_id,
             identity_keys,
+            transaction_id,
         });
 
         Ok(())

--- a/src/identity_committer.rs
+++ b/src/identity_committer.rs
@@ -416,6 +416,9 @@ impl IdentityCommitter {
 
         let identity_keys: Vec<usize> = updates.iter().map(|update| update.leaf_index).collect();
 
+        // This channel's capacity provides us with a natural back-pressure mechanism
+        // to ensure that we don't overwhelm the identity manager with too many
+        // identities to mine.
         pending_identities_sender
             .send(PendingIdentities {
                 transaction_id,

--- a/src/identity_committer.rs
+++ b/src/identity_committer.rs
@@ -426,6 +426,7 @@ impl IdentityCommitter {
         Ok(())
     }
 
+    #[instrument(level = "info", skip_all)]
     pub async fn mine_identities(
         database: &Database,
         identity_manager: &IdentityManager,

--- a/src/identity_committer.rs
+++ b/src/identity_committer.rs
@@ -71,6 +71,10 @@ impl RunningInstance {
 
         info!("Awaiting committer shutdown.");
         self.process_identities_handle.await?;
+
+        info!("Awaiting miner shutdown.");
+        self.mine_identities_handle.await?;
+
         Ok(())
     }
 }

--- a/src/identity_committer.rs
+++ b/src/identity_committer.rs
@@ -416,6 +416,8 @@ impl IdentityCommitter {
         // This channel's capacity provides us with a natural back-pressure mechanism
         // to ensure that we don't overwhelm the identity manager with too many
         // identities to mine.
+        //
+        // Additionally if the receiver is dropped this reserve call will also fail.
         let permit = pending_identities_sender.reserve().await?;
 
         // With all the data prepared we can submit the identities to the on-chain

--- a/src/prover/batch_insertion/mod.rs
+++ b/src/prover/batch_insertion/mod.rs
@@ -1,17 +1,19 @@
 #![allow(unused_variables, dead_code)] // TODO [AA] Remove when this is used outside of tests.
 mod identity;
 
-pub use crate::prover::batch_insertion::identity::Identity;
-use crate::prover::proof::Proof;
-use clap::Parser;
-use ethers::{types::U256, utils::keccak256};
-use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Display, Formatter},
     mem::size_of,
     time::Duration,
 };
+
+use clap::Parser;
+use ethers::{types::U256, utils::keccak256};
+use serde::{Deserialize, Serialize};
 use url::Url;
+
+pub use crate::prover::batch_insertion::identity::Identity;
+use crate::prover::proof::Proof;
 
 /// The endpoint used for proving operations.
 const MTB_PROVE_ENDPOINT: &str = "prove";
@@ -84,7 +86,7 @@ impl Prover {
         start_index: u32,
         pre_root: U256,
         post_root: U256,
-        identities: &Vec<Identity>,
+        identities: &[Identity],
     ) -> anyhow::Result<Proof> {
         if identities.len() != self.batch_size {
             return Err(anyhow::Error::msg(
@@ -458,10 +460,12 @@ mod test {
 #[allow(clippy::wildcard_imports)]
 #[cfg(test)]
 pub mod mock {
-    use super::*;
+    use std::net::SocketAddr;
+
     use axum::{routing::post, Json, Router};
     use axum_server::Handle;
-    use std::net::SocketAddr;
+
+    use super::*;
 
     pub struct Service {
         server: Handle,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
It can take a long time to confirm a transaction on the chain. In that time we could have been already preparing and proving the next batch.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
"Sending" an identities commitment transactions is split into 3 phases:
1. Preparing the proof - prepares proof data and sends it to the prover
2. Sending the transaction - only sends the transaction to the RPC (or OZ Defender Relay)
3. Mining the transaction - awaiting for the transaction to be finalized on chain

The process is synchronized with a channel in such a way that we can already start preparing the next proof while the previous transaction is still unconfirmed.

## Also in this PR1

1. Added `total_proving_time` and `prover_proving_time` metrics

## TODO:
1. [x] ~Tests~ - will work on testing later, codebase needs a bit more work to enable that
2. [ ] Display added metrics on a dashboard

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] ~Added Tests~
- [x] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
