### PR TITLE
Drop pedantic and nursery lints

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly-2022-11-04"
-

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2022-11-04"
+

--- a/src/app.rs
+++ b/src/app.rs
@@ -79,7 +79,6 @@ impl App {
     ///
     /// Will return `Err` if the internal Ethereum handler errors or if the
     /// `options.storage_file` is not accessible.
-    #[allow(clippy::missing_panics_doc)] // TODO
     #[instrument(name = "App::new", level = "debug")]
     pub async fn new(options: Options) -> AnyhowResult<Self> {
         // Connect to Ethereum and Database

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::Result as AnyhowResult;
 use clap::Parser;
-use futures::TryFutureExt;
 use hyper::StatusCode;
 use serde::Serialize;
 use tokio::try_join;
@@ -66,8 +65,6 @@ pub struct Options {
 
 pub struct App {
     database:           Arc<Database>,
-    #[allow(dead_code)]
-    ethereum:           Ethereum,
     identity_manager:   SharedIdentityManager,
     identity_committer: Arc<IdentityCommitter>,
     tree_state:         TreeState,
@@ -82,19 +79,23 @@ impl App {
     #[instrument(name = "App::new", level = "debug")]
     pub async fn new(options: Options) -> AnyhowResult<Self> {
         // Connect to Ethereum and Database
-        let (database, (ethereum, identity_manager)) = {
+        let (database, identity_manager) = {
             let db = Database::new(options.database);
             let prover = BatchInsertionProver::new(&options.prover.batch_insertion)?;
 
-            let eth = Ethereum::new(options.ethereum).and_then(|ethereum| async move {
+            let eth = async move {
+                let ethereum = Ethereum::new(options.ethereum).await?;
+
                 let identity_manager =
                     IdentityManager::new(options.contracts, ethereum.clone(), prover).await?;
-                Ok((ethereum, Arc::new(identity_manager)))
-            });
+
+                Ok(Arc::new(identity_manager))
+            };
 
             // Connect to both in parallel
             try_join!(db, eth)?
         };
+
         let database = Arc::new(database);
 
         let tree_state = Self::initialize_tree(
@@ -123,7 +124,6 @@ impl App {
         // Sync with chain on start up
         let app = Self {
             database,
-            ethereum,
             identity_manager,
             identity_committer,
             tree_state,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+
 use anyhow::{anyhow, Context, Error as ErrReport};
 use clap::Parser;
 use sqlx::{

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 use anyhow::{anyhow, Context, Error as ErrReport};
 use clap::Parser;
 use sqlx::{

--- a/src/ethereum/mod.rs
+++ b/src/ethereum/mod.rs
@@ -12,7 +12,11 @@ use self::write::{TransactionId, WriteProvider};
 
 mod read;
 pub mod write;
+
+#[cfg(not(feature = "oz-provider"))]
 mod write_dev;
+
+#[cfg(feature = "oz-provider")]
 mod write_oz;
 
 // TODO: Log and metrics for signer / nonces.

--- a/src/ethereum/read/mod.rs
+++ b/src/ethereum/read/mod.rs
@@ -49,7 +49,6 @@ pub fn duration_from_str(value: &str) -> Result<Duration, ParseIntError> {
     Ok(Duration::from_secs(u64::from_str(value)?))
 }
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug)]
 pub struct ReadProvider {
     inner:        InnerProvider,

--- a/src/ethereum/read/transport.rs
+++ b/src/ethereum/read/transport.rs
@@ -15,7 +15,6 @@ pub enum Transport {
 }
 
 #[derive(Debug, Error)]
-#[allow(clippy::module_name_repetitions)]
 pub enum TransportError {
     #[error("Http error: {0}")]
     Http(<Http as JsonRpcClient>::Error),

--- a/src/ethereum/write/mod.rs
+++ b/src/ethereum/write/mod.rs
@@ -39,7 +39,6 @@ pub enum TxError {
     Failed(Option<TransactionReceipt>),
 }
 
-#[allow(clippy::module_name_repetitions)]
 #[async_trait]
 pub trait WriteProvider: Sync + Send + Debug {
     async fn send_transaction(

--- a/src/ethereum/write_dev/estimator.rs
+++ b/src/ethereum/write_dev/estimator.rs
@@ -7,7 +7,6 @@ use thiserror::Error;
 
 /// Estimator Provider Errors
 #[derive(Error, Debug)]
-#[allow(clippy::module_name_repetitions)]
 pub enum EstimatorError<Inner: Middleware> {
     #[error("{0}")]
     /// Thrown when an internal middleware errors
@@ -39,8 +38,6 @@ impl<Inner: Middleware> Estimator<Inner> {
         }
     }
 
-    #[allow(clippy::cast_precision_loss)]
-    #[allow(clippy::cast_lossless)]
     pub fn rescale(&self, gas: U256) -> U256 {
         let gas = {
             let n = (256_u32 - 64).saturating_sub(gas.leading_zeros());

--- a/src/ethereum/write_dev/mod.rs
+++ b/src/ethereum/write_dev/mod.rs
@@ -273,8 +273,6 @@ impl Provider {
     }
 
     #[instrument(level = "info", skip(self))]
-    #[allow(clippy::option_if_let_else)] // Less readable
-    #[allow(clippy::cast_precision_loss)]
     async fn send_transaction_unlogged(
         &self,
         tx: TypedTransaction,

--- a/src/ethereum/write_dev/mod.rs
+++ b/src/ethereum/write_dev/mod.rs
@@ -1,8 +1,11 @@
-use self::{estimator::Estimator, gas_oracle_logger::GasOracleLogger, min_gas_fees::MinGasFees};
-use super::{
-    read::ReadProvider,
-    write::{TransactionId, TxError, WriteProvider},
-};
+#![allow(
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    clippy::cast_lossless
+)]
+
+use std::{sync::Arc, time::Duration};
+
 use anyhow::{anyhow, Result as AnyhowResult};
 use async_trait::async_trait;
 use clap::Parser;
@@ -29,9 +32,14 @@ use prometheus::{
     register_int_counter_vec, Counter, Gauge, Histogram, IntCounterVec,
 };
 use reqwest::Client as ReqwestClient;
-use std::{sync::Arc, time::Duration};
 use tokio::time::timeout;
 use tracing::{debug_span, error, info, info_span, instrument, warn, Instrument};
+
+use self::{estimator::Estimator, gas_oracle_logger::GasOracleLogger, min_gas_fees::MinGasFees};
+use super::{
+    read::ReadProvider,
+    write::{TransactionId, TxError, WriteProvider},
+};
 
 mod estimator;
 mod gas_oracle_logger;

--- a/src/ethereum/write_dev/mod.rs
+++ b/src/ethereum/write_dev/mod.rs
@@ -144,7 +144,6 @@ impl WriteProvider for Provider {
 }
 
 impl Provider {
-    #[allow(dead_code)]
     pub async fn new(read_provider: ReadProvider, options: Options) -> AnyhowResult<Self> {
         let legacy = read_provider.legacy;
 

--- a/src/ethereum/write_oz/mod.rs
+++ b/src/ethereum/write_oz/mod.rs
@@ -47,7 +47,6 @@ pub struct Provider {
 }
 
 impl Provider {
-    #[allow(dead_code)]
     pub async fn new(options: &Options) -> AnyhowResult<Self> {
         let relay = OzRelay::new(options).await?;
 

--- a/src/identity_committer.rs
+++ b/src/identity_committer.rs
@@ -62,7 +62,7 @@ impl RunningInstance {
         // which is impossible, since this is the only use, and this method takes
         // ownership, or the channel is closed, which means the committer thread is
         // already dead.
-        let _ = self.shutdown_sender.send(()).await;
+        let _: Result<_, _> = self.shutdown_sender.send(()).await;
         info!("Awaiting committer shutdown.");
         self.handle.await?;
         Ok(())

--- a/src/identity_committer.rs
+++ b/src/identity_committer.rs
@@ -31,7 +31,6 @@ use crate::{
 const DEBOUNCE_THRESHOLD_SECS: u64 = 1;
 
 struct RunningInstance {
-    #[allow(dead_code)]
     handle:          JoinHandle<()>,
     wake_up_sender:  mpsc::Sender<()>,
     shutdown_sender: mpsc::Sender<()>,

--- a/src/identity_committer.rs
+++ b/src/identity_committer.rs
@@ -76,7 +76,8 @@ impl RunningInstance {
         // which is impossible, since this is the only use, and this method takes
         // ownership, or the channel is closed, which means the committer thread is
         // already dead.
-        let _ = self.shutdown_sender.send(()).await;
+        let _ = self.shutdown_sender.send(());
+
         info!("Awaiting committer shutdown.");
         self.process_identities_handle.await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../Readme.md")]
-#![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
+#![warn(clippy::all, clippy::cargo)]
 
 pub mod app;
 mod contracts;
@@ -30,7 +30,6 @@ pub struct Options {
 /// ```
 /// assert!(true);
 /// ```
-#[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 pub async fn main(options: Options) -> AnyhowResult<()> {
     // Create App struct
     let app = Arc::new(App::new(options.app).await?);
@@ -71,7 +70,6 @@ pub mod test {
     #[tokio::test]
     #[allow(clippy::disallowed_methods)] // False positive from macro
     #[traced_test]
-    #[allow(clippy::semicolon_if_nothing_returned)] // False positive
     async fn async_test_with_log() {
         // Local log
         info!("This is being logged on the info level");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../Readme.md")]
-#![warn(clippy::all, clippy::cargo)]
+#![warn(clippy::all, clippy::pedantic, clippy::cargo)]
+#![allow(clippy::module_name_repetitions, clippy::wildcard_imports)]
 
 pub mod app;
 mod contracts;
@@ -32,6 +33,7 @@ pub struct Options {
 /// ```
 /// assert!(true);
 /// ```
+#[allow(clippy::missing_errors_doc)]
 pub async fn main(options: Options) -> AnyhowResult<()> {
     // Create App struct
     let app = Arc::new(App::new(options.app).await?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,13 @@ mod prover;
 pub mod server;
 mod utils;
 
-use crate::app::App;
+use std::sync::Arc;
+
 use anyhow::Result as AnyhowResult;
 use clap::Parser;
-use std::sync::Arc;
 use tracing::info;
+
+use crate::app::App;
 
 #[derive(Clone, Debug, PartialEq, Parser)]
 #[group(skip)]
@@ -46,18 +48,10 @@ pub async fn main(options: Options) -> AnyhowResult<()> {
 
 #[cfg(test)]
 pub mod test {
-    use super::*;
-    use proptest::proptest;
     use tracing::{error, warn};
     use tracing_test::traced_test;
 
-    #[test]
-    #[allow(clippy::eq_op)]
-    fn test_with_proptest() {
-        proptest!(|(a in 0..5, b in 0..5)| {
-            assert_eq!(a + b, b + a);
-        });
-    }
+    use super::*;
 
     #[test]
     #[allow(clippy::disallowed_methods)] // False positive from macro
@@ -91,12 +85,13 @@ pub mod test {
 #[cfg(feature = "bench")]
 #[doc(hidden)]
 pub mod bench {
+    use std::time::Duration;
+
     use criterion::{black_box, BatchSize, Criterion};
     use proptest::{
         strategy::{Strategy, ValueTree},
         test_runner::TestRunner,
     };
-    use std::time::Duration;
     use tokio::runtime;
 
     pub fn group(criterion: &mut Criterion) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../Readme.md")]
-#![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
+#![warn(clippy::all, clippy::cargo)]
 
 use cli_batteries::{run, version};
 use signup_sequencer::{main as sequencer_app, Options};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../Readme.md")]
-#![warn(clippy::all, clippy::cargo)]
+#![warn(clippy::all, clippy::pedantic, clippy::cargo)]
+#![allow(clippy::module_name_repetitions, clippy::wildcard_imports)]
 
 use cli_batteries::{run, version};
 use signup_sequencer::{main as sequencer_app, Options};

--- a/src/prover/batch_insertion/mod.rs
+++ b/src/prover/batch_insertion/mod.rs
@@ -455,7 +455,6 @@ mod test {
 "#;
 }
 
-#[allow(clippy::wildcard_imports)]
 #[cfg(test)]
 pub mod mock {
     use super::*;

--- a/src/prover/batch_insertion/mod.rs
+++ b/src/prover/batch_insertion/mod.rs
@@ -1,4 +1,3 @@
-#![allow(unused_variables, dead_code)] // TODO [AA] Remove when this is used outside of tests.
 mod identity;
 
 pub use crate::prover::batch_insertion::identity::Identity;

--- a/src/server.rs
+++ b/src/server.rs
@@ -114,8 +114,8 @@ pub enum Error {
 
 impl Error {
     fn to_response(&self) -> hyper::Response<Body> {
-        #[allow(clippy::enum_glob_use)]
         use Error::*;
+
         let status_code = match self {
             InvalidMethod => StatusCode::METHOD_NOT_ALLOWED,
             InvalidPath => StatusCode::NOT_FOUND,
@@ -319,7 +319,7 @@ mod test {
 }
 
 #[cfg(feature = "bench")]
-#[allow(clippy::wildcard_imports, unused_imports)]
+#[allow(unused_imports)]
 #[doc(hidden)]
 pub mod bench {
     use super::*;

--- a/src/server.rs
+++ b/src/server.rs
@@ -115,6 +115,7 @@ pub enum Error {
 }
 
 impl Error {
+    #[allow(clippy::enum_glob_use)]
     fn to_response(&self) -> hyper::Response<Body> {
         use Error::*;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,9 @@
-use crate::{app::App, database, identity_tree::Hash};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener},
+    sync::Arc,
+    time::Duration,
+};
+
 use ::prometheus::{opts, register_counter, register_histogram, Counter, Histogram};
 use anyhow::{bail, ensure, Context, Error as EyreError, Result as AnyhowResult};
 use clap::Parser;
@@ -13,15 +18,12 @@ use hyper::{
 use once_cell::sync::Lazy;
 use prometheus::{register_int_counter_vec, IntCounterVec};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener},
-    sync::Arc,
-    time::Duration,
-};
 use thiserror::Error;
 use tokio::time::timeout;
 use tracing::{error, info, instrument, trace};
 use url::{Host, Url};
+
+use crate::{app::App, database, identity_tree::Hash};
 
 #[derive(Clone, Debug, PartialEq, Eq, Parser)]
 #[group(skip)]
@@ -257,19 +259,20 @@ pub async fn bind_from_listener(
         // Clone here as `make_service_fn` is called for every connection
         let app = app.clone();
         let serve_timeout = serve_timeout;
+
         async move {
             Ok::<_, hyper::Error>(service_fn(move |req| {
                 // Clone here as `service_fn` is called for every request
                 let app = app.clone();
                 let serve_timeout = serve_timeout;
+
                 async move {
                     timeout(serve_timeout, route(req, app))
                         .await
                         .unwrap_or_else(|err| {
                             error!(?err, timeout = ?serve_timeout, "Timeout while handling request");
-                            panic!("Sequencer may be stalled, terminating.");
-                            #[allow(unreachable_code)]
-                            Ok(Error::Elapsed(err).to_response())
+
+                            panic!("Sequencer may be stalled, terminating.")
                         })
                 }
             }))
@@ -290,14 +293,14 @@ pub async fn bind_from_listener(
 #[cfg(test)]
 #[allow(unused_imports)]
 mod test {
-    use super::*;
     use hyper::{body::to_bytes, Request, StatusCode};
     use serde_json::json;
 
+    use super::*;
+
     // TODO: Fix test
     // #[tokio::test]
-    #[allow(dead_code)]
-    async fn test_inclusion_proof() {
+    async fn _test_inclusion_proof() {
         let options = crate::app::Options::try_parse_from([""]).unwrap();
         let app = Arc::new(App::new(options).await.unwrap());
         let body = Body::from(
@@ -322,10 +325,11 @@ mod test {
 #[allow(unused_imports)]
 #[doc(hidden)]
 pub mod bench {
-    use super::*;
-    use crate::bench::runtime;
     use criterion::{black_box, Criterion};
     use hyper::body::to_bytes;
+
+    use super::*;
+    use crate::bench::runtime;
 
     pub fn group(_c: &mut Criterion) {
         //     bench_hello_world(c);


### PR DESCRIPTION
Hey, I noticed with have a lot of `#[allow`  or `#![allow` attributes sprinkled around the codebase:

```
Non-clippy:
#![allow(unused_variables, dead_code)]
#[allow(dead_code)]
#[allow(unreachable_code)]
#[allow(unused_imports)]
#[allow(dead_code)]
#[allow(unreachable_patterns)]
#[allow(deprecated)]
#[allow(dead_code)]
#[allow(dead_code)]

Correctness:
#[allow(clippy::eq_op)]

Complexity:
#![allow(clippy::extra_unused_lifetimes)]

Style:
#[allow(clippy::disallowed_methods)]
#[allow(clippy::disallowed_methods)]

Perf:
#[allow(clippy::large_enum_variant)]
#[allow(clippy::large_enum_variant)]

Pedantic:
#![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
#![allow(clippy::cast_precision_loss)]
#[allow(clippy::semicolon_if_nothing_returned)]
#[allow(clippy::enum_glob_use)]
#[allow(clippy::wildcard_imports, unused_imports)]
#[allow(clippy::cast_precision_loss)]
#[allow(clippy::cast_lossless)]
#[allow(clippy::module_name_repetitions)]
#[allow(clippy::module_name_repetitions)]
#[allow(clippy::module_name_repetitions)]
#[allow(clippy::module_name_repetitions)]
#[allow(clippy::module_name_repetitions)]
#[allow(clippy::missing_panics_doc)]
#[allow(clippy::wildcard_imports)]
#[allow(clippy::missing_panics_doc)]
#[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]

Nursery:
#![allow(clippy::option_if_let_else)]
```

Some of them seem reasonable but it looks like the majority of these allow attributes are from the Pedantic group of lints.

In this PR I propose to drop the pedantic and nursery (the option_if_let_else one really rubs me the wrong way) lints and the respective `allow` attributes.
