### PR TITLE
fix: name of production job to deploy app from phone/main

### DIFF
--- a/.github/workflows/phone-build-test-deploy.yml
+++ b/.github/workflows/phone-build-test-deploy.yml
@@ -365,7 +365,7 @@ jobs:
           -f deploy/phone-main-stage.values.yaml
 
   deploy-main-prod:
-    name: Deploy main to staging
+    name: Deploy main to production
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/phone/main'
     needs: [accept]


### PR DESCRIPTION
It was copied by mistake from the staging deploy job.