### PR TITLE
Replace `replace_with` with `take_mut::take` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5577,6 +5577,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sqlx",
+ "take_mut",
  "tempfile",
  "thiserror",
  "tokio",
@@ -5918,6 +5919,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ semaphore = { git = "https://github.com/worldcoin/semaphore-rs", branch = "main"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "any", "postgres", "chrono"] }
+take_mut = "0.2.2"
 tempfile = "3.3.0"
 thiserror = "1.0"
 tokio = { version = "1.17", features = ["signal", "macros", "rt", "sync", "time", "rt-multi-thread", "tracing", "test-util"] }

--- a/src/identity_tree.rs
+++ b/src/identity_tree.rs
@@ -1,10 +1,9 @@
-use chrono::Utc;
 use std::{
     str::FromStr,
     sync::{Arc, Mutex, MutexGuard},
 };
 
-use crate::utils;
+use chrono::Utc;
 use semaphore::{
     lazy_merkle_tree,
     lazy_merkle_tree::LazyMerkleTree,
@@ -198,7 +197,7 @@ where
 
 impl BasicTreeOps for TreeVersionData<lazy_merkle_tree::Canonical> {
     fn update(&mut self, leaf_index: usize, element: Hash) {
-        utils::replace_with(&mut self.tree, |tree| {
+        take_mut::take(&mut self.tree, |tree| {
             tree.update_with_mutation(leaf_index, &element)
         });
         self.next_leaf = leaf_index + 1;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use anyhow::{Error as EyreError, Result as AnyhowResult};
 use ethers::types::U256;
 use futures::FutureExt;
-use std::{future::Future, ptr};
+use std::future::Future;
 use tokio::task::JoinHandle;
 use tracing::error;
 
@@ -71,17 +71,4 @@ where
 #[allow(dead_code)]
 pub fn u256_to_f64(value: U256) -> f64 {
     value.to_string().parse::<f64>().unwrap()
-}
-
-/// Enables a pattern of updating a value with a function that takes ownership
-/// and returns a new version of the value. This is akin to `mem::replace`, but
-/// allows more flexibility.
-/// This call is unsafe if `modifier` panics. Therefore, all callers must ensure
-/// that it does not happen.
-pub fn replace_with<T>(value: &mut T, modifier: impl FnOnce(T) -> T) {
-    unsafe {
-        let v = ptr::read(value);
-        let v = modifier(v);
-        ptr::write(value, v);
-    }
 }


### PR DESCRIPTION
`replace_with` should have actually been `unsafe`. But there already exists `take_mut::take` which does exactly what we want while also upholding the safety invariant regarding panics
