### PR TITLE
Batching Support for multiple batch sizes + bug fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,6 +3610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5583,6 +5589,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "hyper",
+ "maplit",
  "once_cell",
  "oz-api",
  "postgres-docker-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ url = "2.2"
 cli-batteries = { version = "0.4.0", features = ["mock-shutdown"] }
 hex = "0.4.3"
 hex-literal = "0.3"
+maplit = "1.0.2"
 postgres-docker-utils = { path = "crates/postgres-docker-utils" }
 proptest = { version = "1.0" }
 regex = { version = "1.7.1", features = ["std"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,17 +8,21 @@ use serde::Serialize;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{info, instrument, warn};
 
-use crate::contracts::{IdentityManager, SharedIdentityManager};
-use crate::database::{self, Database};
-use crate::ethereum::{self, Ethereum};
-use crate::identity_tree::{
-    CanonicalTreeBuilder, Hash, InclusionProof, RootItem, Status, TreeState,
+use crate::{
+    contracts,
+    contracts::{IdentityManager, SharedIdentityManager},
+    database::{self, Database},
+    ethereum::{self, Ethereum},
+    identity_tree::{CanonicalTreeBuilder, Hash, InclusionProof, RootItem, Status, TreeState},
+    prover,
+    prover::ProverMap,
+    server::{Error as ServerError, ToResponseCode, VerifySemaphoreProofRequest},
+    task_monitor,
+    task_monitor::{
+        tasks::insert_identities::{IdentityInsert, OnInsertComplete},
+        TaskMonitor,
+    },
 };
-use crate::prover::ProverMap;
-use crate::server::{Error as ServerError, ToResponseCode, VerifySemaphoreProofRequest};
-use crate::task_monitor::tasks::insert_identities::{IdentityInsert, OnInsertComplete};
-use crate::task_monitor::TaskMonitor;
-use crate::{contracts, prover, task_monitor};
 
 #[derive(Serialize)]
 #[serde(transparent)]

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -5,17 +5,18 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use clap::Parser;
-use ethers::providers::Middleware;
-use ethers::types::{Address, U256};
+use ethers::{
+    providers::Middleware,
+    types::{Address, U256},
+};
 use semaphore::Field;
 use tracing::{error, info, instrument};
 
 use self::abi::BatchingContract as ContractAbi;
-use crate::ethereum::write::TransactionId;
-use crate::ethereum::{Ethereum, ReadProvider};
-use crate::prover::batch_insertion::Identity;
-use crate::prover::proof::Proof;
-use crate::prover::ProverMap;
+use crate::{
+    ethereum::{write::TransactionId, Ethereum, ReadProvider},
+    prover::{batch_insertion::Identity, proof::Proof, ProverMap},
+};
 
 /// Configuration options for the component responsible for interacting with the
 /// contract.

--- a/src/identity_tree.rs
+++ b/src/identity_tree.rs
@@ -6,7 +6,7 @@ use std::{
 use chrono::Utc;
 use semaphore::{
     lazy_merkle_tree,
-    lazy_merkle_tree::LazyMerkleTree,
+    lazy_merkle_tree::{Derived, LazyMerkleTree},
     merkle_tree::Hasher,
     poseidon_tree::{PoseidonHash, Proof},
     Field,
@@ -99,7 +99,13 @@ pub struct CanonicalTreeMetadata {
 /// Additional data held by any derived tree version. Includes the list of
 /// updates performed since previous version.
 pub struct DerivedTreeMetadata {
-    diff: Vec<TreeUpdate>,
+    diff: Vec<TreeUpdateWithTree>,
+}
+
+#[derive(Clone)]
+pub struct TreeUpdateWithTree {
+    pub update: TreeUpdate,
+    pub tree:   PoseidonTree<Derived>,
 }
 
 /// Trait used to associate a version marker with its metadata type.
@@ -156,48 +162,48 @@ where
 
     /// Returns _up to_ `maximum_update_count` updates that are to be applied to
     /// the tree.
-    fn peek_next_updates(&self, maximum_update_count: usize) -> Vec<TreeUpdate> {
-        self.next.as_ref().map_or_else(Vec::new, |next| {
-            let next = next.get_data();
-            next.metadata
-                .diff
-                .iter()
-                .take(maximum_update_count)
-                .cloned()
-                .collect()
-        })
+    fn peek_next_updates(&self, maximum_update_count: usize) -> Vec<TreeUpdateWithTree> {
+        let Some(next) = self.next.as_ref() else { return Vec::new(); };
+
+        let next = next.get_data();
+        next.metadata
+            .diff
+            .iter()
+            .take(maximum_update_count)
+            .cloned()
+            .collect()
     }
 
     /// Applies the next _up to_ `update_count` updates, returning the merkle
     /// tree proofs obtained after each apply.
-    fn apply_next_updates(&mut self, update_count: usize) -> Vec<Proof> {
-        let mut proofs: Vec<Proof> = vec![];
-        if let Some(next) = self.next.clone() {
-            {
-                // Acquire the exclusive write lock on the next version.
-                let mut next = next.get_data();
+    fn apply_next_updates(&mut self, update_count: usize) {
+        let Some(next) = self.next.clone() else { return; };
 
-                // Get the updates to be applied and apply them sequentially. It is very
-                // important that we record the merkle proof after each step as they depend on
-                // each other.
-                let updates: Vec<&TreeUpdate> =
-                    next.metadata.diff.iter().take(update_count).collect();
-                for update in &updates {
-                    self.update(update.leaf_index, update.element);
-                    let proof = self.tree.proof(update.leaf_index);
-                    proofs.push(proof);
-                }
+        {
+            // Acquire the exclusive write lock on the next version.
+            let mut next = next.get_data();
 
-                // Remove only the updates that have been consumed, which may be all of them.
-                next.metadata.diff = if next.metadata.diff.len() > updates.len() {
-                    Vec::from(&next.metadata.diff[updates.len()..])
-                } else {
-                    vec![]
-                }
+            let updates: Vec<&TreeUpdate> = next
+                .metadata
+                .diff
+                .iter()
+                .map(|u| &u.update)
+                .take(update_count)
+                .collect();
+
+            for update in &updates {
+                self.update(update.leaf_index, update.element);
             }
-            self.garbage_collect();
+
+            // Remove only the updates that have been consumed, which may be all of them.
+            next.metadata.diff = if next.metadata.diff.len() > updates.len() {
+                Vec::from(&next.metadata.diff[updates.len()..])
+            } else {
+                vec![]
+            }
         }
-        proofs
+
+        self.garbage_collect();
     }
 }
 
@@ -232,12 +238,10 @@ impl BasicTreeOps for TreeVersionData<lazy_merkle_tree::Canonical> {
 }
 
 impl TreeVersionData<lazy_merkle_tree::Derived> {
-    /// Reapplies all changes of the given tree. This is only used for garbage
-    /// collection – `tree` will usually be a more densely stored version of the
-    /// base tree, unless we're already inserting past the dense prefix.
     fn rebuild_on(&mut self, mut tree: PoseidonTree<lazy_merkle_tree::Derived>) {
-        for update in &self.metadata.diff {
-            tree = tree.update(update.leaf_index, &update.element);
+        for update in &mut self.metadata.diff {
+            tree = tree.update(update.update.leaf_index, &update.update.element);
+            update.tree = tree.clone();
         }
         self.tree = tree;
         let next = &self.next;
@@ -249,11 +253,17 @@ impl TreeVersionData<lazy_merkle_tree::Derived> {
 
 impl BasicTreeOps for TreeVersionData<lazy_merkle_tree::Derived> {
     fn update(&mut self, leaf_index: usize, element: Hash) {
-        self.tree = self.tree.update(leaf_index, &element);
+        let updated_tree = self.tree.update(leaf_index, &element);
+
+        self.tree = updated_tree.clone();
+
         self.next_leaf = leaf_index + 1;
-        self.metadata.diff.push(TreeUpdate {
-            leaf_index,
-            element,
+        self.metadata.diff.push(TreeUpdateWithTree {
+            update: TreeUpdate {
+                leaf_index,
+                element,
+            },
+            tree:   updated_tree,
         });
     }
 
@@ -393,8 +403,8 @@ impl TreeVersion<Latest> {
 /// Public API for working with versions that have a successor. Such versions
 /// only allow peeking and applying updates from the successor.
 pub trait TreeWithNextVersion {
-    fn peek_next_updates(&self, maximum_update_count: usize) -> Vec<TreeUpdate>;
-    fn apply_next_updates(&self, update_count: usize) -> Vec<Proof>;
+    fn peek_next_updates(&self, maximum_update_count: usize) -> Vec<TreeUpdateWithTree>;
+    fn apply_next_updates(&self, update_count: usize);
 }
 
 impl<V> TreeWithNextVersion for TreeVersion<V>
@@ -402,11 +412,11 @@ where
     V: HasNextVersion,
     TreeVersionData<<V as Version>::TreeVersion>: BasicTreeOps,
 {
-    fn peek_next_updates(&self, maximum_update_count: usize) -> Vec<TreeUpdate> {
+    fn peek_next_updates(&self, maximum_update_count: usize) -> Vec<TreeUpdateWithTree> {
         self.get_data().peek_next_updates(maximum_update_count)
     }
 
-    fn apply_next_updates(&self, update_count: usize) -> Vec<Proof> {
+    fn apply_next_updates(&self, update_count: usize) {
         self.get_data().apply_next_updates(update_count)
     }
 }

--- a/src/identity_tree.rs
+++ b/src/identity_tree.rs
@@ -417,7 +417,7 @@ where
     }
 
     fn apply_next_updates(&self, update_count: usize) {
-        self.get_data().apply_next_updates(update_count)
+        self.get_data().apply_next_updates(update_count);
     }
 }
 

--- a/src/prover/batch_insertion/mod.rs
+++ b/src/prover/batch_insertion/mod.rs
@@ -1,11 +1,12 @@
 mod identity;
 
-use std::fmt::{Display, Formatter};
-use std::mem::size_of;
-use std::time::Duration;
+use std::{
+    fmt::{Display, Formatter},
+    mem::size_of,
+    time::Duration,
+};
 
-use ethers::types::U256;
-use ethers::utils::keccak256;
+use ethers::{types::U256, utils::keccak256};
 use once_cell::sync::Lazy;
 use prometheus::{exponential_buckets, register_histogram, Histogram};
 use serde::{Deserialize, Serialize};
@@ -147,11 +148,6 @@ impl Prover {
         total_proving_time_timer.observe_duration();
 
         Ok(proof)
-    }
-
-    /// Get the size of the batches that the prover is intended to operate on.
-    pub const fn batch_size(&self) -> usize {
-        self.batch_size
     }
 }
 
@@ -482,8 +478,7 @@ mod test {
 pub mod mock {
     use std::net::SocketAddr;
 
-    use axum::routing::post;
-    use axum::{Json, Router};
+    use axum::{routing::post, Json, Router};
     use axum_server::Handle;
 
     use super::*;

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -1,10 +1,13 @@
 pub mod batch_insertion;
 pub mod proof;
 
+use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 
 use clap::Parser;
 use serde::{Deserialize, Serialize};
+
+use self::batch_insertion::Prover;
 
 #[derive(Clone, Debug, PartialEq, Eq, Parser)]
 #[group(skip)]
@@ -18,6 +21,40 @@ pub struct Options {
         default_value = r#"[{"url": "http://localhost:3001","batch_size": 3,"timeout_s": 30}]"#
     )]
     pub prover_urls: JsonWrapper,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProverMap(pub BTreeMap<usize, Prover>);
+
+impl ProverMap {
+    pub fn new(options: &Options) -> anyhow::Result<Self> {
+        let mut map = BTreeMap::new();
+
+        for url in options.prover_urls.0.iter() {
+            map.insert(url.batch_size, Prover::new(url)?);
+        }
+
+        Ok(Self(map))
+    }
+
+    /// Get the smallest prover that can handle the given batch size.
+    pub fn get(&self, batch_size: usize) -> Option<&Prover> {
+        self.0.iter().find_map(|(size, prover)| {
+            if batch_size <= *size {
+                Some(prover)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn max_batch_size(&self) -> usize {
+        self.0
+            .iter()
+            .next_back()
+            .map(|(size, _)| *size)
+            .unwrap_or(0)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -1,8 +1,7 @@
 pub mod batch_insertion;
 pub mod proof;
 
-use std::collections::{BTreeMap, HashMap};
-use std::str::FromStr;
+use std::{collections::BTreeMap, str::FromStr};
 
 use clap::Parser;
 use serde::{Deserialize, Serialize};
@@ -20,25 +19,32 @@ pub struct Options {
         env,
         default_value = r#"[{"url": "http://localhost:3001","batch_size": 3,"timeout_s": 30}]"#
     )]
-    pub prover_urls: JsonWrapper,
+    pub prover_urls: ProverOptionsWrapper,
 }
 
+/// A map that contains a prover for each batch size.
+///
+/// Provides utility methods for getting the appropriate provers
+///
+/// The struct is generic over P for testing purposes.
 #[derive(Debug, Clone)]
-pub struct ProverMap(pub BTreeMap<usize, Prover>);
+pub struct ProverMap<P = Prover>(pub BTreeMap<usize, P>);
 
 impl ProverMap {
     pub fn new(options: &Options) -> anyhow::Result<Self> {
         let mut map = BTreeMap::new();
 
-        for url in options.prover_urls.0.iter() {
+        for url in &options.prover_urls.0 {
             map.insert(url.batch_size, Prover::new(url)?);
         }
 
         Ok(Self(map))
     }
+}
 
+impl<P> ProverMap<P> {
     /// Get the smallest prover that can handle the given batch size.
-    pub fn get(&self, batch_size: usize) -> Option<&Prover> {
+    pub fn get(&self, batch_size: usize) -> Option<&P> {
         self.0.iter().find_map(|(size, prover)| {
             if batch_size <= *size {
                 Some(prover)
@@ -49,21 +55,40 @@ impl ProverMap {
     }
 
     pub fn max_batch_size(&self) -> usize {
-        self.0
-            .iter()
-            .next_back()
-            .map(|(size, _)| *size)
-            .unwrap_or(0)
+        self.0.iter().next_back().map_or(0, |(size, _)| *size)
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct JsonWrapper(pub Vec<batch_insertion::Options>);
+pub struct ProverOptionsWrapper(pub Vec<batch_insertion::Options>);
 
-impl FromStr for JsonWrapper {
+impl FromStr for ProverOptionsWrapper {
     type Err = serde_json::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_str(s).map(JsonWrapper)
+        serde_json::from_str(s).map(ProverOptionsWrapper)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prover_map_tests() {
+        let prover_map: ProverMap<usize> = ProverMap(maplit::btreemap! {
+            3 => 3,
+            5 => 5,
+            7 => 7,
+        });
+
+        assert_eq!(prover_map.max_batch_size(), 7);
+
+        assert_eq!(prover_map.get(1), Some(&3));
+        assert_eq!(prover_map.get(2), Some(&3));
+        assert_eq!(prover_map.get(3), Some(&3));
+        assert_eq!(prover_map.get(4), Some(&5));
+        assert_eq!(prover_map.get(7), Some(&7));
+        assert_eq!(prover_map.get(8), None);
     }
 }

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -1,12 +1,32 @@
 pub mod batch_insertion;
 pub mod proof;
 
+use std::str::FromStr;
+
 use clap::Parser;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Parser)]
 #[group(skip)]
 pub struct Options {
-    #[clap(flatten)]
     /// The options for configuring the batch insertion prover service.
-    pub batch_insertion: batch_insertion::Options,
+    ///
+    /// This should be a JSON array containing objects of the following format `{"url": "http://localhost:3001","batch_size": 3,"timeout_s": 30}`
+    #[clap(
+        long,
+        env,
+        default_value = r#"[{"url": "http://localhost:3001","batch_size": 3,"timeout_s": 30}]"#
+    )]
+    pub prover_urls: JsonWrapper,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JsonWrapper(pub Vec<batch_insertion::Options>);
+
+impl FromStr for JsonWrapper {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s).map(JsonWrapper)
+    }
 }

--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -82,7 +82,7 @@ async fn process_identities(
     identity_manager.await_clean_slate().await?;
 
     info!("Starting identity processor.");
-    let batch_size = identity_manager.batch_size();
+    let batch_size = identity_manager.max_batch_size();
 
     // We start a timer and force it to perform one initial tick to avoid an
     // immediate trigger.
@@ -221,7 +221,7 @@ async fn commit_identities(
     let mut merkle_proofs = batching_tree.apply_next_updates(updates.len());
 
     // Grab some variables for sizes to make querying easier.
-    let batch_size = identity_manager.batch_size();
+    let batch_size = identity_manager.max_batch_size();
     let commitment_count = updates.len();
 
     // If these aren't equal then something has gone terribly wrong and is a

--- a/tests/common/chain_mock.rs
+++ b/tests/common/chain_mock.rs
@@ -1,0 +1,213 @@
+use std::{fs::File, io::BufReader, sync::Arc, time::Duration};
+
+use ethers::{
+    abi::AbiEncode,
+    contract::Contract,
+    core::k256::ecdsa::SigningKey,
+    prelude::{
+        artifacts::BytecodeObject, ContractFactory, Http, LocalWallet, NonceManagerMiddleware,
+        Provider, Signer, SignerMiddleware, Wallet,
+    },
+    providers::Middleware,
+    types::{Bytes, H256, U256},
+    utils::{Anvil, AnvilInstance},
+};
+use tracing::instrument;
+
+use super::{abi as ContractAbi, CompiledContract};
+
+pub type SpecialisedContract = Contract<SpecialisedClient>;
+
+pub struct MockChain {
+    pub anvil:            AnvilInstance,
+    pub private_key:      H256,
+    pub identity_manager: SpecialisedContract,
+}
+
+#[instrument(skip_all)]
+pub async fn spawn_mock_chain(
+    initial_root: U256,
+    batch_size: usize,
+    tree_depth: u8,
+) -> anyhow::Result<MockChain> {
+    let chain = Anvil::new().block_time(2u64).spawn();
+    let private_key = H256::from_slice(&chain.keys()[0].to_be_bytes());
+
+    let provider = Provider::<Http>::try_from(chain.endpoint())
+        .expect("Failed to initialize chain endpoint")
+        .interval(Duration::from_millis(500u64));
+
+    let chain_id = provider.get_chainid().await?.as_u64();
+
+    let wallet = LocalWallet::from(chain.keys()[0].clone()).with_chain_id(chain_id);
+
+    // connect the wallet to the provider
+    let client = SignerMiddleware::new(provider, wallet.clone());
+    let client = NonceManagerMiddleware::new(client, wallet.address());
+    let client = Arc::new(client);
+
+    // Loading the semaphore verifier contract is special as it requires replacing
+    // the address of the Pairing library.
+    let pairing_library_factory = load_and_build_contract("./sol/Pairing.json", client.clone())?;
+    let pairing_library = pairing_library_factory
+        .deploy(())?
+        .confirmations(0usize)
+        .send()
+        .await?;
+
+    let verifier_path = "./sol/SemaphoreVerifier.json";
+    let verifier_file =
+        File::open(verifier_path).unwrap_or_else(|_| panic!("Failed to open `{verifier_path}`"));
+    let verifier_contract_json: CompiledContract =
+        serde_json::from_reader(BufReader::new(verifier_file))
+            .unwrap_or_else(|_| panic!("Could not parse the compiled contract at {verifier_path}"));
+    let mut verifier_bytecode_object: BytecodeObject = verifier_contract_json.bytecode.object;
+    verifier_bytecode_object
+        .link_fully_qualified(
+            "lib/semaphore/packages/contracts/contracts/base/Pairing.sol:Pairing",
+            pairing_library.address(),
+        )
+        .resolve()
+        .unwrap();
+    if verifier_bytecode_object.is_unlinked() {
+        panic!("Could not link the Pairing library into the Verifier.");
+    }
+
+    let bytecode_bytes = verifier_bytecode_object.as_bytes().unwrap_or_else(|| {
+        panic!("Could not parse the bytecode for the contract at {verifier_path}")
+    });
+    let verifier_factory = ContractFactory::new(
+        verifier_contract_json.abi,
+        bytecode_bytes.clone(),
+        client.clone(),
+    );
+    let semaphore_verifier = verifier_factory.deploy(())?.confirmations(0usize).send();
+
+    // The rest of the contracts can be deployed to the mock chain normally.
+    let mock_state_bridge_factory =
+        load_and_build_contract("./sol/SimpleStateBridge.json", client.clone())?;
+    let mock_state_bridge = mock_state_bridge_factory
+        .deploy(())?
+        .confirmations(0usize)
+        .send();
+
+    let mock_verifier_factory =
+        load_and_build_contract("./sol/SequencerVerifier.json", client.clone())?;
+    let mock_verifier = mock_verifier_factory
+        .deploy(())?
+        .confirmations(0usize)
+        .send();
+
+    let unimplemented_verifier_factory =
+        load_and_build_contract("./sol/UnimplementedTreeVerifier.json", client.clone())?;
+    let unimplemented_verifier = unimplemented_verifier_factory
+        .deploy(())?
+        .confirmations(0usize)
+        .send();
+
+    let (semaphore_verifier, mock_state_bridge, mock_verifier, unimplemented_verifier) = tokio::join!(
+        semaphore_verifier,
+        mock_state_bridge,
+        mock_verifier,
+        unimplemented_verifier
+    );
+
+    let semaphore_verifier = semaphore_verifier?;
+    let mock_state_bridge = mock_state_bridge?;
+    let mock_verifier = mock_verifier?;
+    let unimplemented_verifier = unimplemented_verifier?;
+
+    let verifier_lookup_table_factory =
+        load_and_build_contract("./sol/VerifierLookupTable.json", client.clone())?;
+    let insert_verifiers = verifier_lookup_table_factory
+        .clone()
+        .deploy((batch_size as u64, mock_verifier.address()))?
+        .confirmations(0usize)
+        .send();
+
+    let update_verifiers = verifier_lookup_table_factory
+        .deploy((batch_size as u64, unimplemented_verifier.address()))?
+        .confirmations(0usize)
+        .send();
+
+    let identity_manager_impl_factory =
+        load_and_build_contract("./sol/WorldIDIdentityManagerImplV1.json", client.clone())?;
+
+    let identity_manager_impl = identity_manager_impl_factory
+        .deploy(())?
+        .confirmations(0usize)
+        .send();
+
+    let (insert_verifiers, update_verifiers, identity_manager_impl) =
+        tokio::join!(insert_verifiers, update_verifiers, identity_manager_impl);
+
+    let insert_verifiers = insert_verifiers?;
+    let update_verifiers = update_verifiers?;
+    let identity_manager_impl = identity_manager_impl?;
+
+    let identity_manager_factory =
+        load_and_build_contract("./sol/WorldIDIdentityManager.json", client.clone())?;
+    let state_bridge_address = mock_state_bridge.address();
+    let enable_state_bridge = true;
+    let identity_manager_impl_address = identity_manager_impl.address();
+
+    let init_call_data = ContractAbi::InitializeCall {
+        tree_depth,
+        initial_root,
+        batch_insertion_verifiers: insert_verifiers.address(),
+        batch_update_verifiers: update_verifiers.address(),
+        semaphore_verifier: semaphore_verifier.address(),
+        enable_state_bridge,
+        state_bridge: state_bridge_address,
+    };
+    let init_call_encoded: Bytes = Bytes::from(init_call_data.encode());
+
+    let identity_manager_contract = identity_manager_factory
+        .deploy((identity_manager_impl_address, init_call_encoded))?
+        .confirmations(0usize)
+        .send()
+        .await?;
+
+    let identity_manager: SpecialisedContract = Contract::new(
+        identity_manager_contract.address(),
+        ContractAbi::BATCHINGCONTRACT_ABI.clone(),
+        client.clone(),
+    );
+
+    Ok(MockChain {
+        anvil: chain,
+        private_key,
+        identity_manager,
+    })
+}
+
+type SpecialisedClient =
+    NonceManagerMiddleware<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>;
+type SharableClient = Arc<SpecialisedClient>;
+type SpecialisedFactory = ContractFactory<SpecialisedClient>;
+
+fn load_and_build_contract(
+    path: impl Into<String>,
+    client: SharableClient,
+) -> anyhow::Result<SpecialisedFactory> {
+    let path_string = path.into();
+    let contract_file = File::open(&path_string)
+        .unwrap_or_else(|_| panic!("Failed to open `{pth}`", pth = &path_string));
+
+    let contract_json: CompiledContract = serde_json::from_reader(BufReader::new(contract_file))
+        .unwrap_or_else(|_| {
+            panic!(
+                "Could not parse the compiled contract at {pth}",
+                pth = &path_string
+            )
+        });
+    let contract_bytecode = contract_json.bytecode.object.as_bytes().unwrap_or_else(|| {
+        panic!(
+            "Could not parse the bytecode for the contract at {pth}",
+            pth = &path_string
+        )
+    });
+    let contract_factory =
+        ContractFactory::new(contract_json.abi, contract_bytecode.clone(), client);
+    Ok(contract_factory)
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -148,7 +148,7 @@ pub async fn test_inclusion_proof(
     uri: &str,
     client: &Client<HttpConnector>,
     leaf_index: usize,
-    ref_tree: &mut PoseidonTree,
+    ref_tree: &PoseidonTree,
     leaf: &Hash,
     expect_failure: bool,
 ) {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,6 +4,7 @@
 #![allow(dead_code)]
 
 pub mod abi;
+mod chain_mock;
 mod prover_mock;
 
 pub mod prelude {
@@ -46,19 +47,20 @@ pub mod prelude {
     pub use super::{
         abi as ContractAbi, generate_reference_proof_json, generate_test_identities,
         init_tracing_subscriber, prover_mock::ProverService, spawn_app, spawn_deps,
-        test_inclusion_proof, test_insert_identity, test_verify_proof, test_verify_proof_on_chain,
+        spawn_mock_prover, test_inclusion_proof, test_insert_identity, test_verify_proof,
+        test_verify_proof_on_chain,
     };
 }
 
-use ethers::contract::Contract;
 use std::{
-    fs::File,
-    io::BufReader,
     net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener},
     sync::Arc,
 };
 
-use self::prelude::*;
+use self::{
+    chain_mock::{spawn_mock_chain, MockChain, SpecialisedContract},
+    prelude::*,
+};
 
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all)]
@@ -317,7 +319,7 @@ pub async fn spawn_deps(
 ) -> anyhow::Result<(MockChain, DockerContainerGuard, ProverService)> {
     let chain = spawn_mock_chain(initial_root, batch_size, tree_depth);
     let db_container = spawn_db();
-    let prover = spawn_mock_prover();
+    let prover = spawn_mock_prover(batch_size);
 
     let (chain, db_container, prover) = tokio::join!(chain, db_container, prover);
 
@@ -330,203 +332,10 @@ async fn spawn_db() -> anyhow::Result<DockerContainerGuard> {
     Ok(db_container)
 }
 
-pub struct MockChain {
-    pub anvil:            AnvilInstance,
-    pub private_key:      H256,
-    pub identity_manager: SpecialisedContract,
-}
-
-#[instrument(skip_all)]
-async fn spawn_mock_chain(
-    initial_root: U256,
-    batch_size: usize,
-    tree_depth: u8,
-) -> anyhow::Result<MockChain> {
-    let chain = Anvil::new().block_time(2u64).spawn();
-    let private_key = H256::from_slice(&chain.keys()[0].to_be_bytes());
-
-    let provider = Provider::<Http>::try_from(chain.endpoint())
-        .expect("Failed to initialize chain endpoint")
-        .interval(Duration::from_millis(500u64));
-
-    let chain_id = provider.get_chainid().await?.as_u64();
-
-    let wallet = LocalWallet::from(chain.keys()[0].clone()).with_chain_id(chain_id);
-
-    // connect the wallet to the provider
-    let client = SignerMiddleware::new(provider, wallet.clone());
-    let client = NonceManagerMiddleware::new(client, wallet.address());
-    let client = Arc::new(client);
-
-    // Loading the semaphore verifier contract is special as it requires replacing
-    // the address of the Pairing library.
-    let pairing_library_factory = load_and_build_contract("./sol/Pairing.json", client.clone())?;
-    let pairing_library = pairing_library_factory
-        .deploy(())?
-        .confirmations(0usize)
-        .send()
-        .await?;
-
-    let verifier_path = "./sol/SemaphoreVerifier.json";
-    let verifier_file =
-        File::open(verifier_path).unwrap_or_else(|_| panic!("Failed to open `{verifier_path}`"));
-    let verifier_contract_json: CompiledContract =
-        serde_json::from_reader(BufReader::new(verifier_file))
-            .unwrap_or_else(|_| panic!("Could not parse the compiled contract at {verifier_path}"));
-    let mut verifier_bytecode_object: BytecodeObject = verifier_contract_json.bytecode.object;
-    verifier_bytecode_object
-        .link_fully_qualified(
-            "lib/semaphore/packages/contracts/contracts/base/Pairing.sol:Pairing",
-            pairing_library.address(),
-        )
-        .resolve()
-        .unwrap();
-    if verifier_bytecode_object.is_unlinked() {
-        panic!("Could not link the Pairing library into the Verifier.");
-    }
-
-    let bytecode_bytes = verifier_bytecode_object.as_bytes().unwrap_or_else(|| {
-        panic!("Could not parse the bytecode for the contract at {verifier_path}")
-    });
-    let verifier_factory = ContractFactory::new(
-        verifier_contract_json.abi,
-        bytecode_bytes.clone(),
-        client.clone(),
-    );
-    let semaphore_verifier = verifier_factory.deploy(())?.confirmations(0usize).send();
-
-    // The rest of the contracts can be deployed to the mock chain normally.
-    let mock_state_bridge_factory =
-        load_and_build_contract("./sol/SimpleStateBridge.json", client.clone())?;
-    let mock_state_bridge = mock_state_bridge_factory
-        .deploy(())?
-        .confirmations(0usize)
-        .send();
-
-    let mock_verifier_factory =
-        load_and_build_contract("./sol/SequencerVerifier.json", client.clone())?;
-    let mock_verifier = mock_verifier_factory
-        .deploy(())?
-        .confirmations(0usize)
-        .send();
-
-    let unimplemented_verifier_factory =
-        load_and_build_contract("./sol/UnimplementedTreeVerifier.json", client.clone())?;
-    let unimplemented_verifier = unimplemented_verifier_factory
-        .deploy(())?
-        .confirmations(0usize)
-        .send();
-
-    let (semaphore_verifier, mock_state_bridge, mock_verifier, unimplemented_verifier) = tokio::join!(
-        semaphore_verifier,
-        mock_state_bridge,
-        mock_verifier,
-        unimplemented_verifier
-    );
-
-    let semaphore_verifier = semaphore_verifier?;
-    let mock_state_bridge = mock_state_bridge?;
-    let mock_verifier = mock_verifier?;
-    let unimplemented_verifier = unimplemented_verifier?;
-
-    let verifier_lookup_table_factory =
-        load_and_build_contract("./sol/VerifierLookupTable.json", client.clone())?;
-    let insert_verifiers = verifier_lookup_table_factory
-        .clone()
-        .deploy((batch_size as u64, mock_verifier.address()))?
-        .confirmations(0usize)
-        .send();
-
-    let update_verifiers = verifier_lookup_table_factory
-        .deploy((batch_size as u64, unimplemented_verifier.address()))?
-        .confirmations(0usize)
-        .send();
-
-    let identity_manager_impl_factory =
-        load_and_build_contract("./sol/WorldIDIdentityManagerImplV1.json", client.clone())?;
-    let identity_manager_impl = identity_manager_impl_factory
-        .deploy(())?
-        .confirmations(0usize)
-        .send();
-
-    let (insert_verifiers, update_verifiers, identity_manager_impl) =
-        tokio::join!(insert_verifiers, update_verifiers, identity_manager_impl);
-
-    let insert_verifiers = insert_verifiers?;
-    let update_verifiers = update_verifiers?;
-    let identity_manager_impl = identity_manager_impl?;
-
-    let identity_manager_factory =
-        load_and_build_contract("./sol/WorldIDIdentityManager.json", client.clone())?;
-    let state_bridge_address = mock_state_bridge.address();
-    let enable_state_bridge = true;
-    let identity_manager_impl_address = identity_manager_impl.address();
-    let init_call_data = ContractAbi::InitializeCall {
-        tree_depth,
-        initial_root,
-        batch_insertion_verifiers: insert_verifiers.address(),
-        batch_update_verifiers: update_verifiers.address(),
-        semaphore_verifier: semaphore_verifier.address(),
-        enable_state_bridge,
-        state_bridge: state_bridge_address,
-    };
-    let init_call_encoded: Bytes = Bytes::from(init_call_data.encode());
-
-    let identity_manager_contract = identity_manager_factory
-        .deploy((identity_manager_impl_address, init_call_encoded))?
-        .confirmations(0usize)
-        .send()
-        .await?;
-
-    let identity_manager: SpecialisedContract = Contract::new(
-        identity_manager_contract.address(),
-        ContractAbi::BATCHINGCONTRACT_ABI.clone(),
-        client.clone(),
-    );
-
-    Ok(MockChain {
-        anvil: chain,
-        private_key,
-        identity_manager,
-    })
-}
-
-async fn spawn_mock_prover() -> anyhow::Result<ProverService> {
-    let mock_prover_service = prover_mock::ProverService::new().await?;
+pub async fn spawn_mock_prover(batch_size: usize) -> anyhow::Result<ProverService> {
+    let mock_prover_service = prover_mock::ProverService::new(batch_size).await?;
 
     Ok(mock_prover_service)
-}
-
-type SpecialisedClient =
-    NonceManagerMiddleware<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>;
-type SharableClient = Arc<SpecialisedClient>;
-type SpecialisedFactory = ContractFactory<SpecialisedClient>;
-type SpecialisedContract = Contract<SpecialisedClient>;
-
-fn load_and_build_contract(
-    path: impl Into<String>,
-    client: SharableClient,
-) -> anyhow::Result<SpecialisedFactory> {
-    let path_string = path.into();
-    let contract_file = File::open(&path_string)
-        .unwrap_or_else(|_| panic!("Failed to open `{pth}`", pth = &path_string));
-
-    let contract_json: CompiledContract = serde_json::from_reader(BufReader::new(contract_file))
-        .unwrap_or_else(|_| {
-            panic!(
-                "Could not parse the compiled contract at {pth}",
-                pth = &path_string
-            )
-        });
-    let contract_bytecode = contract_json.bytecode.object.as_bytes().unwrap_or_else(|| {
-        panic!(
-            "Could not parse the bytecode for the contract at {pth}",
-            pth = &path_string
-        )
-    });
-    let contract_factory =
-        ContractFactory::new(contract_json.abi, contract_bytecode.clone(), client);
-    Ok(contract_factory)
 }
 
 /// Initializes the tracing subscriber.
@@ -546,7 +355,7 @@ pub fn init_tracing_subscriber() {
             .with_line_number(true)
             .with_env_filter("info,signup_sequencer=debug")
             .with_timer(Uptime::default())
-            .pretty()
+            // .pretty()
             .try_init()
     };
     if let Err(error) = result {

--- a/tests/common/prover_mock.rs
+++ b/tests/common/prover_mock.rs
@@ -163,6 +163,16 @@ impl ProverService {
     pub fn stop(self) {
         self.server.shutdown();
     }
+
+    /// Produces an arg string that's compatible with this prover
+    ///
+    /// e.g. `[{"url": "http://localhost:3001","batch_size": 3,"timeout_s": 30}]`
+    pub fn arg_string(&self) -> String {
+        format!(
+            r#"[{{"url": "{}","batch_size": 3,"timeout_s": 30}}]"#,
+            self.url()
+        )
+    }
 }
 
 impl Prover {

--- a/tests/common/prover_mock.rs
+++ b/tests/common/prover_mock.rs
@@ -164,6 +164,10 @@ impl ProverService {
         self.server.shutdown();
     }
 
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
     /// Produces an arg string that's compatible with this prover - can be used
     /// as is in the CLI args
     ///

--- a/tests/common/prover_mock.rs
+++ b/tests/common/prover_mock.rs
@@ -90,13 +90,14 @@ impl ProveResponse {
 
 /// The mock prover service.
 pub struct ProverService {
-    server:  Handle,
-    inner:   Arc<Mutex<Prover>>,
-    address: SocketAddr,
+    server:     Handle,
+    inner:      Arc<Mutex<Prover>>,
+    address:    SocketAddr,
+    batch_size: usize,
 }
 
 struct Prover {
-    is_unavailable: bool,
+    is_available: bool,
 }
 
 impl ProverService {
@@ -106,7 +107,7 @@ impl ProverService {
     /// It provides only a single endpoint for now, `/prove` in order to match
     /// the full service (`semaphore-mtb`). This can be extended in the future
     /// if needed.
-    pub async fn new() -> anyhow::Result<Self> {
+    pub async fn new(batch_size: usize) -> anyhow::Result<Self> {
         async fn prove(
             State(state): State<Arc<Mutex<Prover>>>,
             Json(input): Json<ProofInput>,
@@ -116,9 +117,7 @@ impl ProverService {
             state.prove(input).map(Json)
         }
 
-        let inner = Arc::new(Mutex::new(Prover {
-            is_unavailable: false,
-        }));
+        let inner = Arc::new(Mutex::new(Prover { is_available: true }));
         let state = inner.clone();
 
         let app = Router::new().route("/prove", post(prove)).with_state(state);
@@ -145,6 +144,7 @@ impl ProverService {
             server,
             inner,
             address,
+            batch_size,
         };
 
         Ok(service)
@@ -156,7 +156,7 @@ impl ProverService {
 
     pub async fn set_availability(&self, availability: bool) {
         let mut inner = self.inner.lock().await;
-        inner.is_unavailable = availability;
+        inner.is_available = availability;
     }
 
     /// Shuts down the server and frees up the socket that it was using.
@@ -164,20 +164,30 @@ impl ProverService {
         self.server.shutdown();
     }
 
-    /// Produces an arg string that's compatible with this prover
+    /// Produces an arg string that's compatible with this prover - can be used
+    /// as is in the CLI args
     ///
     /// e.g. `[{"url": "http://localhost:3001","batch_size": 3,"timeout_s": 30}]`
     pub fn arg_string(&self) -> String {
+        format!("[{}]", self.arg_string_single())
+    }
+
+    /// Produces an arg string that's compatible with this prover - needs to be
+    /// wrapped in an array
+    ///
+    /// e.g. `{"url": "http://localhost:3001","batch_size": 3,"timeout_s": 30}`
+    pub fn arg_string_single(&self) -> String {
         format!(
-            r#"[{{"url": "{}","batch_size": 3,"timeout_s": 30}}]"#,
-            self.url()
+            r#"{{"url": "{}","batch_size": {},"timeout_s": 30}}"#,
+            self.url(),
+            self.batch_size
         )
     }
 }
 
 impl Prover {
     fn prove(&self, input: ProofInput) -> Result<ProveResponse, StatusCode> {
-        if self.is_unavailable {
+        if !self.is_available {
             return Err(StatusCode::SERVICE_UNAVAILABLE);
         }
 

--- a/tests/insert_identity_and_proofs.rs
+++ b/tests/insert_identity_and_proofs.rs
@@ -34,8 +34,8 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         "1",
         "--tree-depth",
         &format!("{tree_depth}"),
-        "--batch-size",
-        &format!("{batch_size}"),
+        "--prover-urls",
+        &prover_mock.arg_string(),
         "--batch-timeout-seconds",
         "10",
         "--dense-tree-prefix-depth",
@@ -53,12 +53,6 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         Url::parse(&mock_chain.anvil.endpoint()).expect("Failed to parse Anvil url");
 
     options.app.ethereum.write_options.signing_key = mock_chain.private_key;
-
-    options
-        .app
-        .prover
-        .batch_insertion
-        .batch_insertion_prover_url = prover_mock.url();
 
     let (app, local_addr) = spawn_app(options.clone())
         .await

--- a/tests/insert_identity_and_proofs.rs
+++ b/tests/insert_identity_and_proofs.rs
@@ -75,7 +75,7 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         &uri,
         &client,
         0,
-        &mut ref_tree,
+        &ref_tree,
         &options.app.contracts.initial_leaf_value,
         true,
     )
@@ -84,7 +84,7 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         &uri,
         &client,
         1,
-        &mut ref_tree,
+        &ref_tree,
         &options.app.contracts.initial_leaf_value,
         true,
     )
@@ -101,7 +101,7 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         &uri,
         &client,
         0,
-        &mut ref_tree,
+        &ref_tree,
         &Hash::from_str_radix(&test_identities[0], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
@@ -111,7 +111,7 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         &uri,
         &client,
         1,
-        &mut ref_tree,
+        &ref_tree,
         &Hash::from_str_radix(&test_identities[1], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
@@ -121,7 +121,7 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         &uri,
         &client,
         2,
-        &mut ref_tree,
+        &ref_tree,
         &Hash::from_str_radix(&test_identities[2], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
@@ -140,7 +140,7 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         &uri,
         &client,
         3,
-        &mut ref_tree,
+        &ref_tree,
         &Hash::from_str_radix(&test_identities[3], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
@@ -150,7 +150,7 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         &uri,
         &client,
         4,
-        &mut ref_tree,
+        &ref_tree,
         &Hash::from_str_radix(&test_identities[4], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
@@ -176,7 +176,7 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         &uri,
         &client,
         0,
-        &mut ref_tree,
+        &ref_tree,
         &Hash::from_str_radix(&test_identities[0], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
@@ -186,7 +186,7 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         &uri,
         &client,
         4,
-        &mut ref_tree,
+        &ref_tree,
         &Hash::from_str_radix(&test_identities[4], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
@@ -213,7 +213,7 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         &uri,
         &client,
         0,
-        &mut ref_tree,
+        &ref_tree,
         &Hash::from_str_radix(&test_identities[0], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
@@ -223,7 +223,7 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
         &uri,
         &client,
         4,
-        &mut ref_tree,
+        &ref_tree,
         &Hash::from_str_radix(&test_identities[4], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,

--- a/tests/multi_prover.rs
+++ b/tests/multi_prover.rs
@@ -93,9 +93,10 @@ async fn multi_prover() -> anyhow::Result<()> {
     tokio::time::sleep(Duration::from_secs(batch_timeout_seconds)).await;
 
     // Identities should have been inserted and processed
-    for i in 0..batch_size_3 {
-        test_inclusion_proof(&uri, &client, i, &mut ref_tree, &identities_ref[i], false).await;
+    for (i, identity) in identities_ref.iter().enumerate().take(batch_size_3) {
+        test_inclusion_proof(&uri, &client, i, &ref_tree, identity, false).await;
     }
+
     // Now re re-enable the larger prover and disable the smaller one
     prover_mock_batch_size_10.set_availability(true).await;
     prover_mock_batch_size_3.set_availability(false).await;
@@ -117,7 +118,7 @@ async fn multi_prover() -> anyhow::Result<()> {
             &uri,
             &client,
             offset + i,
-            &mut ref_tree,
+            &ref_tree,
             &identities_ref[i + offset],
             false,
         )

--- a/tests/multi_prover.rs
+++ b/tests/multi_prover.rs
@@ -1,0 +1,133 @@
+mod common;
+
+use common::prelude::*;
+
+/// Tests that the app can keep running even if the prover returns 500s
+/// and that it will eventually succeed if the prover becomes available again.
+#[tokio::test]
+async fn multi_prover() -> anyhow::Result<()> {
+    init_tracing_subscriber();
+    info!("Starting unavailable prover test");
+
+    let tree_depth: u8 = 20;
+
+    let mut ref_tree = PoseidonTree::new(tree_depth as usize + 1, ruint::Uint::ZERO);
+    let initial_root: U256 = ref_tree.root().into();
+
+    let batch_timeout_seconds: u64 = 2;
+
+    let batch_size_3: usize = 3;
+    let batch_size_10: usize = 10;
+
+    let (mock_chain, db_container, prover_mock_batch_size_3) =
+        spawn_deps(initial_root, batch_size_3, tree_depth).await?;
+
+    let prover_mock_batch_size_10 = spawn_mock_prover(batch_size_10).await?;
+
+    let prover_arg_string = format!(
+        "[{},{}]",
+        prover_mock_batch_size_3.arg_string_single(),
+        prover_mock_batch_size_10.arg_string_single()
+    );
+
+    info!("Running with {prover_arg_string}");
+
+    let port = db_container.port();
+    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let mut options = Options::try_parse_from([
+        "signup-sequencer",
+        "--identity-manager-address",
+        "0x0000000000000000000000000000000000000000", // placeholder, updated below
+        "--database",
+        &db_url,
+        "--database-max-connections",
+        "1",
+        "--tree-depth",
+        &format!("{tree_depth}"),
+        "--prover-urls",
+        &prover_arg_string,
+        "--batch-timeout-seconds",
+        &format!("{batch_timeout_seconds}"),
+        "--dense-tree-prefix-depth",
+        "10",
+        "--tree-gc-threshold",
+        "1",
+    ])
+    .context("Failed to create options")?;
+
+    options.server.server = Url::parse("http://127.0.0.1:0/")?;
+
+    options.app.contracts.identity_manager_address = mock_chain.identity_manager.address();
+    options.app.ethereum.read_options.confirmation_blocks_delay = 2;
+    options.app.ethereum.read_options.ethereum_provider = Url::parse(&mock_chain.anvil.endpoint())?;
+
+    options.app.ethereum.write_options.signing_key = mock_chain.private_key;
+
+    let (app, local_addr) = spawn_app(options.clone())
+        .await
+        .expect("Failed to spawn app.");
+
+    let test_identities = generate_test_identities(batch_size_3 + batch_size_10);
+
+    let identities_ref: Vec<Field> = test_identities
+        .iter()
+        .map(|i| Hash::from_str_radix(i, 16).unwrap())
+        .collect();
+
+    let uri = "http://".to_owned() + &local_addr.to_string();
+    let client = Client::new();
+
+    // We're disabling the larger prover, so that only inserting to the smaller
+    // batch size 3 prover can work
+    prover_mock_batch_size_10.set_availability(false).await;
+    prover_mock_batch_size_3.set_availability(true).await; // on by default, but here for visibility
+
+    // Insert only 3 identities, so that the sequencer is forced to submit a batch
+    // size of 3
+    for i in 0..batch_size_3 {
+        test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, i).await;
+    }
+
+    // Wait until a batch can be produced
+    tokio::time::sleep(Duration::from_secs(batch_timeout_seconds)).await;
+
+    // Identities should have been inserted and processed
+    for i in 0..batch_size_3 {
+        test_inclusion_proof(&uri, &client, i, &mut ref_tree, &identities_ref[i], false).await;
+    }
+    // Now re re-enable the larger prover and disable the smaller one
+    prover_mock_batch_size_10.set_availability(true).await;
+    prover_mock_batch_size_3.set_availability(false).await;
+
+    // Insert 10 identities
+
+    let offset = batch_size_3;
+    for i in 0..batch_size_10 {
+        test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, offset + i).await;
+    }
+
+    // Batch should be immediately produced, we'll wait a little for stability
+    // but we'll less than the batch timeout
+    tokio::time::sleep(Duration::from_secs_f32(batch_timeout_seconds as f32 / 3.0)).await;
+
+    // Identities should have been inserted and processed
+    for i in 0..batch_size_10 {
+        test_inclusion_proof(
+            &uri,
+            &client,
+            offset + i,
+            &mut ref_tree,
+            &identities_ref[i + offset],
+            false,
+        )
+        .await;
+    }
+
+    shutdown();
+    app.await?;
+    prover_mock_batch_size_3.stop();
+    prover_mock_batch_size_10.stop();
+    reset_shutdown();
+
+    Ok(())
+}

--- a/tests/multi_prover.rs
+++ b/tests/multi_prover.rs
@@ -19,10 +19,11 @@ async fn multi_prover() -> anyhow::Result<()> {
     let batch_size_3: usize = 3;
     let batch_size_10: usize = 10;
 
-    let (mock_chain, db_container, prover_mock_batch_size_3) =
-        spawn_deps(initial_root, batch_size_3, tree_depth).await?;
+    let (mock_chain, db_container, prover_map) =
+        spawn_deps(initial_root, &[batch_size_3, batch_size_10], tree_depth).await?;
 
-    let prover_mock_batch_size_10 = spawn_mock_prover(batch_size_10).await?;
+    let prover_mock_batch_size_3 = &prover_map[&batch_size_3];
+    let prover_mock_batch_size_10 = &prover_map[&batch_size_10];
 
     let prover_arg_string = format!(
         "[{},{}]",
@@ -125,8 +126,9 @@ async fn multi_prover() -> anyhow::Result<()> {
 
     shutdown();
     app.await?;
-    prover_mock_batch_size_3.stop();
-    prover_mock_batch_size_10.stop();
+    for (_, prover) in prover_map.into_iter() {
+        prover.stop();
+    }
     reset_shutdown();
 
     Ok(())

--- a/tests/unavailable_prover.rs
+++ b/tests/unavailable_prover.rs
@@ -85,9 +85,9 @@ async fn unavailable_prover() -> anyhow::Result<()> {
     info!("Prover has been reenabled");
 
     // Test that the identities have been inserted and processed
-    test_inclusion_proof(&uri, &client, 0, &mut ref_tree, &identities_ref[0], false).await;
-    test_inclusion_proof(&uri, &client, 1, &mut ref_tree, &identities_ref[1], false).await;
-    test_inclusion_proof(&uri, &client, 2, &mut ref_tree, &identities_ref[2], false).await;
+    test_inclusion_proof(&uri, &client, 0, &ref_tree, &identities_ref[0], false).await;
+    test_inclusion_proof(&uri, &client, 1, &ref_tree, &identities_ref[1], false).await;
+    test_inclusion_proof(&uri, &client, 2, &ref_tree, &identities_ref[2], false).await;
 
     shutdown();
     app.await?;

--- a/tests/unavailable_prover.rs
+++ b/tests/unavailable_prover.rs
@@ -18,6 +18,7 @@ async fn unavailable_prover() -> anyhow::Result<()> {
 
     let (mock_chain, db_container, prover_mock) =
         spawn_deps(initial_root, batch_size, tree_depth).await?;
+
     prover_mock.set_availability(false).await;
 
     let port = db_container.port();

--- a/tests/unavailable_prover.rs
+++ b/tests/unavailable_prover.rs
@@ -32,8 +32,8 @@ async fn unavailable_prover() -> anyhow::Result<()> {
         "1",
         "--tree-depth",
         &format!("{tree_depth}"),
-        "--batch-size",
-        &format!("{batch_size}"),
+        "--prover-urls",
+        &prover_mock.arg_string(),
         "--batch-timeout-seconds",
         "10",
         "--dense-tree-prefix-depth",
@@ -50,12 +50,6 @@ async fn unavailable_prover() -> anyhow::Result<()> {
     options.app.ethereum.read_options.ethereum_provider = Url::parse(&mock_chain.anvil.endpoint())?;
 
     options.app.ethereum.write_options.signing_key = mock_chain.private_key;
-
-    options
-        .app
-        .prover
-        .batch_insertion
-        .batch_insertion_prover_url = prover_mock.url();
 
     let (app, local_addr) = spawn_app(options.clone())
         .await

--- a/tests/validate_proofs.rs
+++ b/tests/validate_proofs.rs
@@ -101,7 +101,7 @@ async fn validate_proofs() -> anyhow::Result<()> {
     )
     .await;
 
-    test_inclusion_proof(&uri, &client, 0, &mut ref_tree, &TEST_LEAVES[0], false).await;
+    test_inclusion_proof(&uri, &client, 0, &ref_tree, &TEST_LEAVES[0], false).await;
 
     test_verify_proof_on_chain(
         &identity_manager,

--- a/tests/validate_proofs.rs
+++ b/tests/validate_proofs.rs
@@ -34,10 +34,10 @@ async fn validate_proofs() -> anyhow::Result<()> {
         "1",
         "--tree-depth",
         &format!("{tree_depth}"),
+        "--prover-urls",
+        &prover_mock.arg_string(),
         "--batch-timeout-seconds",
         "1",
-        "--batch-size",
-        &format!("{batch_size}"),
     ])
     .expect("Failed to create options");
     options.server.server = Url::parse("http://127.0.0.1:0/").expect("Failed to parse URL");
@@ -47,12 +47,6 @@ async fn validate_proofs() -> anyhow::Result<()> {
     options.app.ethereum.read_options.ethereum_provider =
         Url::parse(&mock_chain.anvil.endpoint()).expect("Failed to parse ganache endpoint");
     options.app.ethereum.write_options.signing_key = mock_chain.private_key;
-
-    options
-        .app
-        .prover
-        .batch_insertion
-        .batch_insertion_prover_url = prover_mock.url();
 
     let (app, local_addr) = spawn_app(options.clone())
         .await

--- a/tests/validate_proofs.rs
+++ b/tests/validate_proofs.rs
@@ -17,8 +17,11 @@ async fn validate_proofs() -> anyhow::Result<()> {
     let tree_depth: u8 = SUPPORTED_DEPTH as u8;
     let batch_size = 3;
 
-    let (mock_chain, db_container, prover_mock) =
-        spawn_deps(initial_root, batch_size, tree_depth).await?;
+    let (mock_chain, db_container, prover_map) =
+        spawn_deps(initial_root, &[batch_size], tree_depth).await?;
+
+    let prover_mock = &prover_map[&batch_size];
+
     let identity_manager = mock_chain.identity_manager.clone();
 
     let port = db_container.port();
@@ -206,7 +209,9 @@ async fn validate_proofs() -> anyhow::Result<()> {
     // Shutdown the app properly for the final time
     shutdown();
     app.await.unwrap();
-    prover_mock.stop();
+    for (_, prover) in prover_map.into_iter() {
+        prover.stop();
+    }
     reset_shutdown();
 
     Ok(())


### PR DESCRIPTION
Changes:
1. The sequencer no longer accepts the following cli args `--batch-size`, `--batch-insertion-prover-timeout` or `--batch-insertion-prover-url`,
    instead it accepts `--prover-urls` which accepts a JSON list of the following format: `[{"url": "http://localhost:3001","batch_size": 3,"timeout_s": 30}]`
2. If sending a batch which is not full - the sequencer will choose the smallest batch size out of the available provers that can contain the entire batch
3. Fixes a bug that would leave the sequencer in an invalid state if the `process_identitites` task failed or panicked