### PR TITLE
Batching/submit txs in parallel

### DIFF
--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -125,6 +125,9 @@ async fn process_identities(
                 ).await?;
 
                 last_batch_time = SystemTime::now();
+
+                // Also wake up if woken up due to a tick
+                wake_up_notify.notify_one();
             }
             _ = wake_up_notify.notified() => {
                 tracing::trace!("Identity batch insertion woken due to request.");


### PR DESCRIPTION
Increasing the capacity of this channel should yield in much faster batch submission rate.

Currently we're bottlenecked not by the prover but by the rate at which transactions are being finalized.

This should enable us to process pending identities faster.

And since the `process_identities` is a singular task - there should be no contention or race condition behaviour