### PR TITLE
Validate that transaction has not been reverted

### DIFF
--- a/crates/oz-api/src/data/transactions/mod.rs
+++ b/crates/oz-api/src/data/transactions/mod.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 
 use chrono::{DateTime, Utc};
-use ethers::types::{Bytes, NameOrAddress, U256};
+use ethers::types::{Bytes, NameOrAddress, H256, U256};
 use serde::{Deserialize, Serialize};
 
 /// OpenZeppelin Defender transaction status.
@@ -62,6 +62,9 @@ pub struct SendBaseTransactionRequest<'a> {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RelayerTransactionBase {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub hash:           Option<H256>,
     pub transaction_id: String,
     pub to:             NameOrAddress,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/ethereum/mod.rs
+++ b/src/ethereum/mod.rs
@@ -52,7 +52,7 @@ impl Ethereum {
 
         #[cfg(feature = "oz-provider")]
         let write_provider: Arc<dyn WriteProvider> =
-            Arc::new(write_oz::Provider::new(&options.write_options).await?);
+            Arc::new(write_oz::Provider::new(read_provider.clone(), &options.write_options).await?);
 
         Ok(Self {
             read_provider: Arc::new(read_provider),

--- a/src/ethereum/write_oz/mod.rs
+++ b/src/ethereum/write_oz/mod.rs
@@ -3,13 +3,16 @@ use std::time::Duration;
 use anyhow::Result as AnyhowResult;
 use async_trait::async_trait;
 use clap::Parser;
-use ethers::types::{transaction::eip2718::TypedTransaction, Address, H160};
+use ethers::{
+    providers::Middleware,
+    types::{transaction::eip2718::TypedTransaction, Address, H160, U64},
+};
 
 use self::openzeppelin::OzRelay;
 use super::{
     read::duration_from_str,
     write::{TransactionId, WriteProvider},
-    TxError,
+    ReadProvider, TxError,
 };
 
 mod error;
@@ -43,16 +46,18 @@ pub struct Options {
 
 #[derive(Debug)]
 pub struct Provider {
-    inner:   OzRelay,
-    address: Address,
+    read_provider: ReadProvider,
+    inner:         OzRelay,
+    address:       Address,
 }
 
 impl Provider {
-    pub async fn new(options: &Options) -> AnyhowResult<Self> {
+    pub async fn new(read_provider: ReadProvider, options: &Options) -> AnyhowResult<Self> {
         let relay = OzRelay::new(options).await?;
 
         Ok(Self {
-            inner:   relay,
+            read_provider,
+            inner: relay,
             address: options.oz_address,
         })
     }
@@ -73,7 +78,33 @@ impl WriteProvider for Provider {
     }
 
     async fn mine_transaction(&self, tx: TransactionId) -> Result<(), TxError> {
-        self.inner.mine_transaction(tx).await
+        let oz_transaction = self.inner.mine_transaction(tx).await?;
+
+        let tx_hash = oz_transaction.hash.ok_or_else(|| {
+            TxError::Fetch(From::from(format!(
+                "Failed to get tx hash for transaction id {}",
+                oz_transaction.transaction_id
+            )))
+        })?;
+
+        let tx = self
+            .read_provider
+            .get_transaction_receipt(tx_hash)
+            .await
+            .map_err(|err| TxError::Fetch(err.into()))?;
+
+        let tx = tx.ok_or_else(|| {
+            TxError::Fetch(From::from(format!(
+                "Failed to get transaction receipt for transaction id {}",
+                oz_transaction.transaction_id
+            )))
+        })?;
+
+        if tx.status != Some(U64::from(1u64)) {
+            return Err(TxError::Failed(Some(tx)));
+        }
+
+        Ok(())
     }
 
     fn address(&self) -> Address {

--- a/src/ethereum/write_oz/openzeppelin.rs
+++ b/src/ethereum/write_oz/openzeppelin.rs
@@ -181,10 +181,11 @@ impl OzRelay {
         Ok(TransactionId(tx_id))
     }
 
-    pub async fn mine_transaction(&self, tx_id: TransactionId) -> Result<(), TxError> {
-        self.mine_transaction_id(tx_id.0.as_str()).await?;
-
-        Ok(())
+    pub async fn mine_transaction(
+        &self,
+        tx_id: TransactionId,
+    ) -> Result<RelayerTransactionBase, TxError> {
+        Ok(self.mine_transaction_id(tx_id.0.as_str()).await?)
     }
 
     pub async fn fetch_pending_transactions(&self) -> Result<Vec<TransactionId>, TxError> {


### PR DESCRIPTION
Now we validate that transactions have not been reverted before deciding to mark them as mined