### PR TITLE
redacted password from db url when logging

### DIFF
--- a/src/ethereum/mod.rs
+++ b/src/ethereum/mod.rs
@@ -227,7 +227,7 @@ impl Ethereum {
         // the retry policy?
         let (provider, chain_id, eip1559) = {
             info!(
-                provider = %&options.ethereum_provider,
+                provider_domain = &options.ethereum_provider.domain(),
                 "Connecting to Ethereum"
             );
             let transport = Transport::new(options.ethereum_provider).await?;


### PR DESCRIPTION

On sequencer start-up, I see only 2 areas where sensitive information is stored: database URL and Ethereum provider. 
1. Redacting password from db url is pretty straightforward. This draft PR has a fix for that. Basically, it redacts the password as "********" before logging in the console. 

Output after redacting db url password:  
![image](https://user-images.githubusercontent.com/16568715/234975877-08cb42ca-c092-463e-ae1b-855af680a19a.png)

 2. For redacting API key from Ethereum provider, there is no standard among Node providers on the location of the API key. I am thinking of just logging domain field as shown below. I am open to suggestions for a better approach.
![image](https://user-images.githubusercontent.com/16568715/234976975-e5556706-72c7-4680-a2e1-7cce0dbd092b.png)
