### PR TITLE
Removing sensitive info from logs

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -45,10 +45,7 @@ pub struct Database {
 impl Database {
     #[instrument(skip_all)]
     pub async fn new(options: Options) -> Result<Self, ErrReport> {
-        let mut redacted_db_url = options.database.clone();
-        _ = redacted_db_url.set_password(Some("********"));
-
-        info!(url = %&redacted_db_url, "Connecting to database");
+        info!(url = %&options.database, "Connecting to database");
 
         // Create database if requested and does not exist
         if options.database_migrate && !Postgres::database_exists(options.database.expose()).await?
@@ -69,7 +66,7 @@ impl Database {
             .await
             .context("error getting database version")?
             .get::<String, _>(0);
-        info!(url = %&redacted_db_url, kind = ?pool.any_kind(), ?version, "Connected to database");
+        info!(url = %&options.database, ?version, "Connected to database");
 
         // Run migrations if requested.
         let latest = MIGRATOR
@@ -79,7 +76,7 @@ impl Database {
             .version;
 
         if options.database_migrate {
-            info!(url = %&redacted_db_url, "Running migrations");
+            info!(url = %&options.database, "Running migrations");
             MIGRATOR.run(&pool).await?;
         }
 
@@ -88,7 +85,7 @@ impl Database {
         if let Some((version, dirty)) = pool.acquire().await?.version().await? {
             if dirty {
                 error!(
-                    url = %&redacted_db_url,
+                    url = %&options.database,
                     version,
                     expected = latest,
                     "Database is in incomplete migration state.",
@@ -96,7 +93,7 @@ impl Database {
                 return Err(anyhow!("Database is in incomplete migration state."));
             } else if version < latest {
                 error!(
-                    url = %&redacted_db_url,
+                    url = %&options.database,
                     version,
                     expected = latest,
                     "Database is not up to date, try rerunning with --database-migrate",
@@ -106,7 +103,7 @@ impl Database {
                 ));
             } else if version > latest {
                 error!(
-                    url = %&redacted_db_url,
+                    url = %&options.database,
                     version,
                     latest,
                     "Database version is newer than this version of the software, please update.",
@@ -116,13 +113,13 @@ impl Database {
                 ));
             }
             info!(
-                url = %&redacted_db_url,
+                url = %&options.database,
                 version,
                 latest,
                 "Database version is up to date.",
             );
         } else {
-            error!(url = %&redacted_db_url, "Could not get database version");
+            error!(url = %&options.database, "Could not get database version");
             return Err(anyhow!("Could not get database version."));
         }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -45,13 +45,15 @@ pub struct Database {
 impl Database {
     #[instrument(skip_all)]
     pub async fn new(options: Options) -> Result<Self, ErrReport> {
-        info!(url = %&options.database, "Connecting to database");
+        let mut redacted_db_url = options.database.clone();
+        _ = redacted_db_url.set_password(Some("********"));
+
+        info!(url = %&redacted_db_url, "Connecting to database");
 
         // Create database if requested and does not exist
-        if options.database_migrate && !Postgres::database_exists(options.database.as_str()).await?
-        {
-            warn!(url = %&options.database, "Database does not exist, creating database");
-            Postgres::create_database(options.database.as_str()).await?;
+        if options.database_migrate && !Any::database_exists(options.database.as_str()).await? {
+            warn!(url = %&redacted_db_url, "Database does not exist, creating database");
+            Any::create_database(options.database.as_str()).await?;
         }
 
         // Create a connection pool
@@ -66,8 +68,7 @@ impl Database {
             .await
             .context("error getting database version")?
             .get::<String, _>(0);
-
-        info!(url = %&options.database, ?version, "Connected to database");
+        info!(url = %&redacted_db_url, kind = ?pool.any_kind(), ?version, "Connected to database");
 
         // Run migrations if requested.
         let latest = MIGRATOR
@@ -77,7 +78,7 @@ impl Database {
             .version;
 
         if options.database_migrate {
-            info!(url = %&options.database, "Running migrations");
+            info!(url = %&redacted_db_url, "Running migrations");
             MIGRATOR.run(&pool).await?;
         }
 
@@ -86,7 +87,7 @@ impl Database {
         if let Some((version, dirty)) = pool.acquire().await?.version().await? {
             if dirty {
                 error!(
-                    url = %&options.database,
+                    url = %&redacted_db_url,
                     version,
                     expected = latest,
                     "Database is in incomplete migration state.",
@@ -94,7 +95,7 @@ impl Database {
                 return Err(anyhow!("Database is in incomplete migration state."));
             } else if version < latest {
                 error!(
-                    url = %&options.database,
+                    url = %&redacted_db_url,
                     version,
                     expected = latest,
                     "Database is not up to date, try rerunning with --database-migrate",
@@ -104,7 +105,7 @@ impl Database {
                 ));
             } else if version > latest {
                 error!(
-                    url = %&options.database,
+                    url = %&redacted_db_url,
                     version,
                     latest,
                     "Database version is newer than this version of the software, please update.",
@@ -114,13 +115,13 @@ impl Database {
                 ));
             }
             info!(
-                url = %&options.database,
+                url = %&redacted_db_url,
                 version,
                 latest,
                 "Database version is up to date.",
             );
         } else {
-            error!(url = %&options.database, "Could not get database version");
+            error!(url = %&redacted_db_url, "Could not get database version");
             return Err(anyhow!("Could not get database version."));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod database;
 mod ethereum;
 pub mod identity_tree;
 mod prover;
+pub mod secret;
 pub mod server;
 mod task_monitor;
 mod utils;

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -36,7 +36,7 @@ impl FromStr for SecretUrl {
     type Err = <Url as FromStr>::Err;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Url::from_str(s).map(SecretUrl::new)?)
+        Url::from_str(s).map(SecretUrl::new)
     }
 }
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -119,9 +119,8 @@ mod tests {
 
     #[test]
     fn test_url_expose() {
-        let secret = SecretUrl::new(Secret(
-            Url::from_str("postgres://user:password@localhost:5432/database").unwrap(),
-        ));
+        let secret =
+            SecretUrl::from_str("postgres://user:password@localhost:5432/database").unwrap();
         assert_eq!(
             secret.expose(),
             "postgres://user:password@localhost:5432/database"
@@ -130,9 +129,8 @@ mod tests {
 
     #[test]
     fn test_url_debug() {
-        let secret = SecretUrl::new(Secret(
-            Url::from_str("postgres://user:password@localhost:5432/database").unwrap(),
-        ));
+        let secret =
+            SecretUrl::from_str("postgres://user:password@localhost:5432/database").unwrap();
         assert_eq!(
             format!("{:?}", secret),
             "postgres://**********@localhost:5432/database"

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,8 +1,7 @@
-use serde::Deserialize;
 use std::{fmt, str::FromStr};
 use url::Url;
 
-#[derive(Clone, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Secret<S>(S)
 where
     S: fmt::Debug + AsRef<str>;
@@ -37,11 +36,68 @@ where
     }
 }
 
+//////////////////////////////////////
+// Specific implementations for Url //
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretUrl {
+    url: Secret<Url>,
+}
+
+impl SecretUrl {
+    pub fn new(secret: Secret<Url>) -> Self {
+        Self { url: secret }
+    }
+
+    pub fn expose(&self) -> &str {
+        self.url.expose()
+    }
+
+    fn format(&self) -> String {
+        if self.url.0.has_authority() {
+            let mut url = self.url.0.clone();
+            if url.password().is_some() {
+                url.set_password(None).unwrap();
+            }
+            url.set_username("**********").unwrap();
+            return url.to_string();
+        }
+        self.url.0.to_string()
+    }
+}
+
+impl AsRef<str> for SecretUrl {
+    fn as_ref(&self) -> &str {
+        self.url.0.as_str()
+    }
+}
+
 impl FromStr for Secret<Url> {
     type Err = <Url as FromStr>::Err;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Url::from_str(s).map(Secret::new)
+    }
+}
+
+impl FromStr for SecretUrl {
+    type Err = <Url as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let secret = Url::from_str(s).map(Secret::new)?;
+        Ok(Self::new(secret))
+    }
+}
+
+impl fmt::Display for SecretUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.format())
+    }
+}
+
+impl fmt::Debug for SecretUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.format())
     }
 }
 
@@ -59,5 +115,27 @@ mod tests {
     fn test_debug() {
         let secret = Secret(String::from("password@something!"));
         assert_eq!(format!("{:?}", secret), "**********");
+    }
+
+    #[test]
+    fn test_url_expose() {
+        let secret = SecretUrl::new(Secret(
+            Url::from_str("postgres://user:password@localhost:5432/database").unwrap(),
+        ));
+        assert_eq!(
+            secret.expose(),
+            "postgres://user:password@localhost:5432/database"
+        );
+    }
+
+    #[test]
+    fn test_url_debug() {
+        let secret = SecretUrl::new(Secret(
+            Url::from_str("postgres://user:password@localhost:5432/database").unwrap(),
+        ));
+        assert_eq!(
+            format!("{:?}", secret),
+            "postgres://**********@localhost:5432/database"
+        );
     }
 }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -10,7 +10,7 @@ impl SecretUrl {
     }
 
     pub fn expose(&self) -> &str {
-        self.as_ref()
+        self.0.as_str()
     }
 
     fn format(&self) -> Url {
@@ -22,12 +22,6 @@ impl SecretUrl {
             url.set_username("**********").unwrap();
         }
         url
-    }
-}
-
-impl AsRef<str> for SecretUrl {
-    fn as_ref(&self) -> &str {
-        self.0.as_str()
     }
 }
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,0 +1,63 @@
+use serde::Deserialize;
+use std::{fmt, str::FromStr};
+use url::Url;
+
+#[derive(Clone, Eq, PartialEq, Deserialize)]
+pub struct Secret<S>(S)
+where
+    S: fmt::Debug + AsRef<str>;
+
+impl<S> Secret<S>
+where
+    S: fmt::Debug + AsRef<str>,
+{
+    pub fn new(value: S) -> Secret<S> {
+        Secret(value)
+    }
+
+    pub fn expose(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+impl<S> fmt::Debug for Secret<S>
+where
+    S: fmt::Debug + AsRef<str>,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("**********")
+    }
+}
+
+impl<S> fmt::Display for Secret<S>
+where
+    S: fmt::Debug + AsRef<str>,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("**********")
+    }
+}
+
+impl FromStr for Secret<Url> {
+    type Err = <Url as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Url::from_str(s).map(Secret::new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expose() {
+        let secret = Secret(String::from("password@something!"));
+        assert_eq!(secret.expose(), "password@something!");
+    }
+
+    #[test]
+    fn test_debug() {
+        let secret = Secret(String::from("password@something!"));
+        assert_eq!(format!("{:?}", secret), "**********");
+    }
+}

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -107,13 +107,13 @@ mod tests {
 
     #[test]
     fn test_expose() {
-        let secret = Secret(String::from("password@something!"));
+        let secret = Secret::from_str("password@something!").unwrap();
         assert_eq!(secret.expose(), "password@something!");
     }
 
     #[test]
     fn test_debug() {
-        let secret = Secret(String::from("password@something!"));
+        let secret = Secret::from_str("password@something!").unwrap();
         assert_eq!(format!("{:?}", secret), "**********");
     }
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -13,16 +13,15 @@ impl SecretUrl {
         self.as_ref()
     }
 
-    fn format(&self) -> String {
-        if self.0.has_authority() {
-            let mut url = self.0.clone();
+    fn format(&self) -> Url {
+        let mut url = self.0.clone();
+        if url.has_authority() {
             if url.password().is_some() {
                 url.set_password(None).unwrap();
             }
             url.set_username("**********").unwrap();
-            return url.to_string();
         }
-        self.0.to_string()
+        url
     }
 }
 
@@ -42,13 +41,13 @@ impl FromStr for SecretUrl {
 
 impl fmt::Display for SecretUrl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.format())
+        self.format().fmt(f)
     }
 }
 
 impl fmt::Debug for SecretUrl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.format())
+        self.format().fmt(f)
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -31,6 +31,7 @@ use error::Error;
 
 mod api_metrics_layer;
 mod extract_trace_layer;
+mod remove_auth_layer;
 mod timeout_layer;
 
 #[derive(Clone, Debug, PartialEq, Eq, Parser)]
@@ -221,6 +222,7 @@ pub async fn bind_from_listener(
                 .on_response(DefaultOnResponse::new().level(Level::INFO)),
         )
         .layer(middleware::from_fn(extract_trace_layer::middleware))
+        .layer(middleware::from_fn(remove_auth_layer::middleware))
         .with_state(app.clone());
 
     let server = axum::Server::from_tcp(listener)?

--- a/src/server/remove_auth_layer.rs
+++ b/src/server/remove_auth_layer.rs
@@ -1,0 +1,12 @@
+use axum::{
+    http::{header::AUTHORIZATION, Request, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+
+pub async fn middleware<B>(mut request: Request<B>, next: Next<B>) -> Result<Response, StatusCode> {
+    request.headers_mut().remove(AUTHORIZATION);
+
+    let response = next.run(request).await;
+    Ok(response)
+}


### PR DESCRIPTION
This PR introduces SecretUrl that prevents log macro with exposing username:password
