### PR TITLE
Add tree restore

### DIFF
--- a/src/identity_tree.rs
+++ b/src/identity_tree.rs
@@ -525,18 +525,20 @@ impl CanonicalTreeBuilder {
         flattening_threshold: usize,
         initial_leaf: Field,
         initial_leaves: &[Field],
+        mmap_file_path: String,
     ) -> Self {
         let initial_leaves_in_dense_count = min(initial_leaves.len(), 1 << dense_prefix_depth);
         let (initial_leaves_in_dense, leftover_initial_leaves) =
             initial_leaves.split_at(initial_leaves_in_dense_count);
 
         let tree =
-            PoseidonTree::<lazy_merkle_tree::Canonical>::new_with_dense_prefix_with_initial_values(
+            PoseidonTree::<lazy_merkle_tree::Canonical>::new_mmapped_with_dense_prefix_with_init_values(
                 tree_depth,
                 dense_prefix_depth,
                 &initial_leaf,
                 initial_leaves_in_dense,
-            );
+                &mmap_file_path
+            ).unwrap();
         let metadata = CanonicalTreeMetadata {
             flatten_threshold:        flattening_threshold,
             count_since_last_flatten: 0,
@@ -554,6 +556,39 @@ impl CanonicalTreeBuilder {
             });
         }
         builder
+    }
+
+    pub fn restore(
+        tree_depth: usize,
+        dense_prefix_depth: usize,
+        initial_leaf: &Field,
+        flattening_threshold: usize,
+        mmap_file_path: &String,
+    ) -> Option<Self> {
+        let tree = match PoseidonTree::<lazy_merkle_tree::Canonical>::attempt_dense_mmap_restore(
+            tree_depth,
+            dense_prefix_depth,
+            &initial_leaf,
+            &mmap_file_path,
+        ) {
+            Ok(tree) => tree,
+            Err(error) => {
+                warn!("Tree wasn't trestored. Reason: {}", error.to_string());
+                return None;
+            }
+        };
+        let metadata = CanonicalTreeMetadata {
+            flatten_threshold:        flattening_threshold,
+            count_since_last_flatten: 0,
+        };
+        let builder = Self(TreeVersionData {
+            tree,
+            next_leaf: 1 << dense_prefix_depth,
+            metadata,
+            next: None,
+        });
+
+        Some(builder)
     }
 
     /// Updates a leaf in the resulting tree.


### PR DESCRIPTION
This PR depends on [this semaphore PR](https://github.com/worldcoin/semaphore-rs/pull/45).
The merge should be done after semaphore PR is merged.

Adds functions to attempt and restore a tree, if it fails it builds a new one
