### PR TITLE
Panic on register identities tx error

### DIFF
--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -364,14 +364,15 @@ async fn commit_identities(
         )
         .await;
 
-    if let Err(err) = transaction_result {
-        panic!(
-            "Failed to insert identity to contract due to error {err}. Restarting sequencer to \
-             reconstruct local tree"
-        );
-    }
-
-    let transaction_id = transaction_result.unwrap();
+     let transaction_id = match transaction_result  {
+        Err(err) => {
+            panic!(
+                "Failed to insert identity to contract due to error {err}. Restarting sequencer to \
+                 reconstruct local tree"
+            );
+        },
+        Ok(transaction_id) => transaction_id,
+    };
 
     info!(
         start_index,

--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -364,9 +364,10 @@ async fn commit_identities(
         )
         .await;
 
-    if let Some(err) = transaction_result {
+    if let Err(err) = transaction_result {
         panic!(
-            "Failed to insert identity to contract due to error {err}. Restarting sequencer to reconstruct local tree"
+            "Failed to insert identity to contract due to error {err}. Restarting sequencer to \
+             reconstruct local tree"
         );
     }
 

--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -364,13 +364,13 @@ async fn commit_identities(
         )
         .await;
 
-     let transaction_id = match transaction_result  {
+    let transaction_id = match transaction_result {
         Err(err) => {
             panic!(
-                "Failed to insert identity to contract due to error {err}. Restarting sequencer to \
-                 reconstruct local tree"
+                "Failed to insert identity to contract due to error {err}. Restarting sequencer \
+                 to reconstruct local tree"
             );
-        },
+        }
         Ok(transaction_id) => transaction_id,
     };
 

--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -364,13 +364,9 @@ async fn commit_identities(
         )
         .await;
 
-    if transaction_result.is_err() {
-        transaction_result.map_err(|e| {
-            error!(?e, "Failed to insert identity to contract.");
-            e
-        })?;
+    if let Some(err) = transaction_result {
         panic!(
-            "Failed to insert identity to contract. Restarting sequencer to reconstruct local tree"
+            "Failed to insert identity to contract due to error {err}. Restarting sequencer to reconstruct local tree"
         );
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

We've seen errors caused by OZ returning `out of gas` errors on identity registration. When that happened, the sequencer tried to send the next batch, even though the previous one errored. That's because we don't have a retry at this level. To mitigate this problem, we'll panic when this problem happens. This will ensure we retry the faulty batch.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
