### PR TITLE
Deletion proof padding

### DIFF
--- a/src/contracts/abi.rs
+++ b/src/contracts/abi.rs
@@ -7,7 +7,7 @@ abigen!(
     r#"[
         struct RootInfo { uint256 root; uint128 supersededTimestamp; bool isValid }
         function registerIdentities(uint256[8] calldata insertionProof, uint256 preRoot, uint32 startIndex, uint256[] calldata identityCommitments, uint256 postRoot) public virtual
-        function deleteIdentities(uint256[8] calldata deletionProof, uint256 preRoot, uint32[] calldata deletionIndices, uint256 postRoot) public virtual 
+        function deleteIdentities(uint256[8] calldata deletionProof, uint256 preRoot, bytes calldata deletionIndices, uint256 postRoot) public virtual 
         function latestRoot() public view virtual returns (uint256 root)
         function owner() public view virtual returns (address)
         function queryRoot(uint256 root) public view virtual returns (RootInfo memory)

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use clap::Parser;
+use ethers::abi::ethabi::Bytes;
 use ethers::providers::Middleware;
 use ethers::types::{Address, U256};
 use semaphore::Field;
@@ -294,9 +295,19 @@ impl IdentityManager {
         // We want to send the transaction through our ethereum provider rather than
         // directly now. To that end, we create it, and then send it later, waiting for
         // it to complete.
+        let deletion_indices = deletion_indices
+            .iter()
+            .flat_map(|&idx| idx.to_be_bytes().to_vec())
+            .collect::<Vec<u8>>();
+
         let register_identities_transaction = self
             .abi
-            .delete_identities(proof_points_array, pre_root, deletion_indices, post_root)
+            .delete_identities(
+                proof_points_array,
+                pre_root,
+                deletion_indices.into(),
+                post_root,
+            )
             .tx;
 
         self.ethereum

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -269,11 +269,16 @@ impl Prover {
         let input_hash =
             compute_deletion_proof_input_hash(pre_root, post_root, &identity_commitments);
 
+        let deletion_indices = deletion_indices
+            .iter()
+            .flat_map(|&idx| idx.to_be_bytes().to_vec())
+            .collect::<Vec<u8>>();
+
         let proof_input = DeletionProofInput {
             input_hash,
             pre_root,
             post_root,
-            deletion_indices: deletion_indices.to_vec(),
+            deletion_indices,
             identity_commitments,
             merkle_proofs,
         };
@@ -411,7 +416,8 @@ struct DeletionProofInput {
     input_hash:           U256,
     pre_root:             U256,
     post_root:            U256,
-    deletion_indices:     Vec<u32>,
+    // Packed byte array of u32s representing deletion indices
+    deletion_indices:     Vec<u8>,
     identity_commitments: Vec<U256>,
     merkle_proofs:        Vec<Vec<U256>>,
 }

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -269,16 +269,11 @@ impl Prover {
         let input_hash =
             compute_deletion_proof_input_hash(pre_root, post_root, &identity_commitments);
 
-        let deletion_indices = deletion_indices
-            .iter()
-            .flat_map(|&idx| idx.to_be_bytes().to_vec())
-            .collect::<Vec<u8>>();
-
         let proof_input = DeletionProofInput {
             input_hash,
             pre_root,
             post_root,
-            deletion_indices,
+            deletion_indices: deletion_indices.to_vec(),
             identity_commitments,
             merkle_proofs,
         };
@@ -416,8 +411,7 @@ struct DeletionProofInput {
     input_hash:           U256,
     pre_root:             U256,
     post_root:            U256,
-    // Packed byte array of u32s representing deletion indices
-    deletion_indices:     Vec<u8>,
+    deletion_indices:     Vec<u32>,
     identity_commitments: Vec<U256>,
     merkle_proofs:        Vec<Vec<U256>>,
 }

--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -7,7 +7,7 @@ use chrono::{Days, Utc};
 use ethers::types::U256;
 use once_cell::sync::Lazy;
 use prometheus::{register_histogram, Histogram};
-use semaphore::poseidon_tree::{Branch, PoseidonHash};
+use semaphore::poseidon_tree::Branch;
 use tokio::sync::Notify;
 use tokio::{select, time};
 use tracing::{debug, error, info, instrument, warn};

--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -505,14 +505,12 @@ pub async fn delete_identities(
         .collect::<Vec<u32>>();
 
     // The verifier and prover can only work with a given batch size, so we need to
-    // ensure that our batches match that size. We do this by padding with
-    // subsequent zero identities and their associated merkle proofs if the batch is
-    // too small.
-
-    // TODO: add note that prover will ignore these if the index is 32, add this to
-    // a const
+    // ensure that our batches match that size. We do this by padding deletion
+    // indices with tree.depth() ^ 2. The deletion prover will skip the proof for
+    // any deletion with an index greater than the max tree depth
+    let pad_index = latest_tree_from_updates.depth().pow(2) as u32;
     if commitment_count != batch_size {
-        deletion_indices.extend(vec![32; batch_size - commitment_count]);
+        deletion_indices.extend(vec![pad_index; batch_size - commitment_count]);
     }
 
     assert_eq!(

--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -7,6 +7,7 @@ use chrono::{Days, Utc};
 use ethers::types::U256;
 use once_cell::sync::Lazy;
 use prometheus::{register_histogram, Histogram};
+use ruint::Uint;
 use semaphore::merkle_tree::Proof;
 use semaphore::poseidon_tree::{Branch, PoseidonHash};
 use tokio::sync::Notify;
@@ -515,7 +516,13 @@ pub async fn delete_identities(
         let padding = batch_size - commitment_count;
         commitments.extend(vec![U256::zero(); padding]);
         deletion_indices.extend(vec![pad_index; padding]);
-        merkle_proofs.extend(vec![Proof::<PoseidonHash>(vec![]); padding]);
+
+        let zeroed_proof = Proof(vec![
+            Branch::Left(Uint::ZERO);
+            latest_tree_from_updates.depth()
+        ]);
+
+        merkle_proofs.extend(vec![zeroed_proof; padding]);
     }
 
     assert_eq!(

--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -20,7 +20,7 @@ use crate::identity_tree::{
 };
 use crate::prover::identity::Identity;
 use crate::prover::map::ReadOnlyInsertionProver;
-use crate::prover::{Proof, Prover, ReadOnlyProver};
+use crate::prover::{Prover, ReadOnlyProver};
 use crate::task_monitor::{
     PendingBatchDeletion, PendingBatchInsertion, PendingBatchSubmission, TaskMonitor,
 };


### PR DESCRIPTION
This PR introduces logic to pad deletion proofs. The verifier and prover can only work with a given batch size, so we need to ensure that our batches match that size. We do this by padding deletion indices with tree.depth() ^ 2. The deletion prover will skip the proof for any deletion with an index greater than the max tree depth.