### PR TITLE
Fix: Sync tree state / `get_commitments_by_status` 

### DIFF
--- a/schemas/database/004_identities.up.sql
+++ b/schemas/database/004_identities.up.sql
@@ -22,7 +22,7 @@ ALTER TABLE identities ADD PRIMARY KEY (id);
 -- Create a new sequence manually
 CREATE SEQUENCE identities_id_seq;
 
--- Initialize the SERIAL counter based on the max 'leaf_index' value
+-- Initialize a counter based on the max 'leaf_index' value
 SELECT setval('identities_id_seq', coalesce((SELECT MAX(leaf_index) FROM identities), 1));
 
 -- Set default value of id to use the sequence

--- a/schemas/database/004_identities.up.sql
+++ b/schemas/database/004_identities.up.sql
@@ -1,5 +1,8 @@
 -- Add the new 'id' column
-ALTER TABLE identities ADD COLUMN id BIGSERIAL;
+ALTER TABLE identities ADD COLUMN id BIGINT;
+
+-- Populate 'id' with 'leaf_index'
+UPDATE identities SET id = leaf_index;
 
 -- Set the new 'id' column as NOT NULL
 ALTER TABLE identities ALTER COLUMN id SET NOT NULL;
@@ -7,7 +10,7 @@ ALTER TABLE identities ALTER COLUMN id SET NOT NULL;
 -- Drop the unique commitment constraint to allow for 0x00 to be inserted for deletions
 ALTER TABLE identities DROP CONSTRAINT identities_commitment_key;
 
--- Set the id to be unique
+-- Set 'id' to be unique
 ALTER TABLE identities ADD CONSTRAINT id_unique UNIQUE(id);
 
 -- Drop the existing primary key
@@ -15,3 +18,12 @@ ALTER TABLE identities DROP CONSTRAINT identities_pkey;
 
 -- Set the new 'id' column as the primary key
 ALTER TABLE identities ADD PRIMARY KEY (id);
+
+-- Create a new sequence manually
+CREATE SEQUENCE identities_id_seq;
+
+-- Initialize the SERIAL counter based on the max 'leaf_index' value
+SELECT setval('identities_id_seq', coalesce((SELECT MAX(leaf_index) FROM identities), 1));
+
+-- Set default value of id to use the sequence
+ALTER TABLE identities ALTER COLUMN id SET DEFAULT nextval('identities_id_seq');

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1460,7 +1460,7 @@ mod test {
         }
 
         // Assert that the remaining identities are processed
-        for i in 1..5 {
+        for i in 2..5 {
             assert_eq!(mined_tree_updates[i].element, identities[i]);
             assert_eq!(mined_tree_updates[i].leaf_index, i);
         }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -312,10 +312,10 @@ impl Database {
     ) -> Result<Vec<TreeUpdate>, Error> {
         let query = sqlx::query(
             r#"
-            SELECT leaf_index, commitment
+            SELECT DISTINCT ON (leaf_index) leaf_index, commitment
             FROM identities
             WHERE status = $1
-            ORDER BY leaf_index ASC;
+            ORDER BY leaf_index ASC, id DESC;
             "#,
         )
         .bind(<&str>::from(status));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,7 @@ use tokio::task::JoinHandle;
 use tracing::{error, info};
 
 pub mod index_packing;
+pub mod tree_updates;
 
 pub trait Any<A> {
     fn any(self) -> AnyhowResult<A>;

--- a/src/utils/tree_updates.rs
+++ b/src/utils/tree_updates.rs
@@ -1,0 +1,58 @@
+use crate::identity_tree::TreeUpdate;
+
+pub fn dedup_tree_updates(updates: Vec<TreeUpdate>) -> Vec<TreeUpdate> {
+    let mut deduped = Vec::new();
+    let mut temp: Option<TreeUpdate> = None;
+
+    for update in updates {
+        if let Some(prev) = temp {
+            if prev.leaf_index == update.leaf_index {
+                temp = Some(update);
+            } else {
+                deduped.push(prev);
+                temp = Some(update);
+            }
+        } else {
+            temp = Some(update);
+        }
+    }
+
+    if let Some(item) = temp {
+        deduped.push(item);
+    }
+
+    deduped
+}
+
+#[cfg(test)]
+mod tests {
+    use semaphore::Field;
+
+    use super::*;
+    use crate::identity_tree::Hash;
+
+    #[test]
+    fn deduplicates_tree_updates() {
+        let hashes: Vec<Hash> = (0..10).map(Field::from).collect();
+
+        let updates = vec![
+            TreeUpdate::new(0, hashes[0]),
+            TreeUpdate::new(1, hashes[1]),
+            TreeUpdate::new(1, hashes[2]),
+            TreeUpdate::new(1, hashes[3]),
+            TreeUpdate::new(2, hashes[4]),
+            TreeUpdate::new(2, hashes[5]),
+            TreeUpdate::new(3, hashes[6]),
+        ];
+        let expected = vec![
+            TreeUpdate::new(0, hashes[0]),
+            TreeUpdate::new(1, hashes[3]),
+            TreeUpdate::new(2, hashes[5]),
+            TreeUpdate::new(3, hashes[6]),
+        ];
+
+        let deduped = dedup_tree_updates(updates);
+
+        assert_eq!(expected, deduped);
+    }
+}

--- a/tests/delete_identities.rs
+++ b/tests/delete_identities.rs
@@ -172,6 +172,21 @@ async fn delete_identities() -> anyhow::Result<()> {
         .await;
     }
 
+    // Ensure that valid proofs can still be received after restart for identities
+    // that have not been deleted
+    for i in deletion_batch_size + 1..insertion_batch_size {
+        test_inclusion_proof(
+            &uri,
+            &client,
+            i,
+            &ref_tree,
+            &Hash::from_str_radix(&test_identities[i], 16)
+                .expect("Failed to parse Hash from test leaf"),
+            false,
+        )
+        .await;
+    }
+
     // Shutdown the app properly for the final time
     shutdown();
     app.await.unwrap();

--- a/tests/delete_identities.rs
+++ b/tests/delete_identities.rs
@@ -145,6 +145,33 @@ async fn delete_identities() -> anyhow::Result<()> {
     // Expect failure when deleting an identity that can not be found
     test_delete_identity(&uri, &client, &mut ref_tree, &identities_ref, 12, true).await;
 
+    // Shutdown the app and reset the mock shutdown, allowing us to test the
+    // behaviour with saved data.
+    info!("Stopping the app for testing purposes");
+    shutdown();
+    app.await.unwrap();
+    reset_shutdown();
+
+    // Test loading the state from a file when the on-chain contract has the state.
+    let (app, local_addr) = spawn_app(options.clone())
+        .await
+        .expect("Failed to spawn app.");
+    let uri = "http://".to_owned() + &local_addr.to_string();
+
+    // Ensure that identities have been deleted
+    for i in 0..deletion_batch_size {
+        test_inclusion_proof(
+            &uri,
+            &client,
+            i,
+            &ref_tree,
+            &Hash::from_str_radix(&test_identities[i], 16)
+                .expect("Failed to parse Hash from test leaf"),
+            true,
+        )
+        .await;
+    }
+
     // Shutdown the app properly for the final time
     shutdown();
     app.await.unwrap();


### PR DESCRIPTION
This PR introduces changes to the identities table to fix tree state syncing on startup. Additionally, `get_commitments_by_status` was updated to only get the `TreeUpdate` at a given leaf index with the highest `id` value.
