### PR TITLE
add insertion timestamp persistence

### DIFF
--- a/schemas/database/010_latest_insertion_timestamp.sql
+++ b/schemas/database/010_latest_insertion_timestamp.sql
@@ -1,0 +1,3 @@
+CREATE TABLE latest_insertion_timestamp (
+    insertion_timestamp TIMESTAMPTZ
+);

--- a/schemas/database/010_latest_insertion_timestamp.sql
+++ b/schemas/database/010_latest_insertion_timestamp.sql
@@ -1,3 +1,6 @@
 CREATE TABLE latest_insertion_timestamp (
-    insertion_timestamp TIMESTAMPTZ
+    Lock char(1)                NOT NULL DEFAULT 'X',
+    insertion_timestamp         TIMESTAMPTZ,
+    constraint PK_T2            PRIMARY KEY (Lock),
+    constraint CK_T2_Locked     CHECK (Lock='X')
 );

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1180,7 +1180,7 @@ mod test {
 
         let latest_insertion_timestamp = db.get_latest_insertion_timestamp().await?.unwrap();
 
-        assert_eq!(latest_insertion_timestamp, insertion_timestamp);
+        assert!(latest_insertion_timestamp.timestamp() - insertion_timestamp.timestamp() <= 1);
 
         Ok(())
     }

--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use anyhow::{Context, Result as AnyhowResult};
 use chrono::{DateTime, Utc};
 use ethers::types::U256;
-use futures_util::TryFutureExt;
-use oz_api::data;
 use ruint::Uint;
 use semaphore::merkle_tree::Proof;
 use semaphore::poseidon_tree::Branch;


### PR DESCRIPTION
## Motivation

If the sequencer halts, the in-memory representation of the last time a batch was inserted is lost, therefore we need to introduce `latest_insertion_timestamp` persistence by writing it to the database.

## Solution

Creates a new table called `latest_insertion_timestamp` and writes the last time a batch was inserted into the merkle tree into `insertion_timestamp`. The value is read from `process_identities` on each call and writes to it after a batch has been committed. 

## PR Checklist

- [x] Added Tests