### PR TITLE
Strengthen postgres-docker-utils

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -369,8 +369,8 @@ impl Database {
     pub async fn get_latest_insertion_timestamp(&self) -> Result<Option<DateTime<Utc>>, Error> {
         let query = sqlx::query(
             r#"
-            SELECT insertion_timestamp 
-            FROM latest_insertion_timestamp 
+            SELECT insertion_timestamp
+            FROM latest_insertion_timestamp
             WHERE Lock = 'X';"#,
         );
 
@@ -835,8 +835,8 @@ mod test {
     // TODO: either use anyhow or eyre
     async fn setup_db() -> anyhow::Result<(Database, DockerContainerGuard)> {
         let db_container = postgres_docker_utils::setup().await?;
-        let port = db_container.port();
-        let url = format!("postgres://postgres:postgres@localhost:{port}/database");
+        let db_socket_addr = db_container.address();
+        let url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
 
         let db = Database::new(Options {
             database:                 SecretUrl::from_str(&url)?,

--- a/tests/delete_identities.rs
+++ b/tests/delete_identities.rs
@@ -35,8 +35,8 @@ async fn delete_identities() -> anyhow::Result<()> {
     let mock_insertion_prover = &insertion_prover_map[&insertion_batch_size];
     let mock_deletion_prover = &deletion_prover_map[&deletion_batch_size];
 
-    let port = db_container.port();
-    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
 
     let mut options = Options::try_parse_from([
         "signup-sequencer",

--- a/tests/delete_padded_identity.rs
+++ b/tests/delete_padded_identity.rs
@@ -35,8 +35,8 @@ async fn delete_padded_identity() -> anyhow::Result<()> {
     let mock_insertion_prover = &insertion_prover_map[&insertion_batch_size];
     let mock_deletion_prover = &deletion_prover_map[&deletion_batch_size];
 
-    let port = db_container.port();
-    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
 
     let mut options = Options::try_parse_from([
         "signup-sequencer",

--- a/tests/dynamic_batch_sizes.rs
+++ b/tests/dynamic_batch_sizes.rs
@@ -36,8 +36,8 @@ async fn dynamic_batch_sizes() -> anyhow::Result<()> {
     let first_prover = &insertion_prover_map[&first_batch_size];
     let second_prover = &insertion_prover_map[&second_batch_size];
 
-    let port = db_container.port();
-    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
 
     // We initially spawn the service with a single prover for batch size 3.
 

--- a/tests/insert_identity_and_proofs.rs
+++ b/tests/insert_identity_and_proofs.rs
@@ -23,8 +23,8 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
 
     let prover_mock = &insertion_prover_map[&batch_size];
 
-    let port = db_container.port();
-    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
 
     let mut options = Options::try_parse_from([
         "signup-sequencer",

--- a/tests/malformed_payload.rs
+++ b/tests/malformed_payload.rs
@@ -22,8 +22,8 @@ async fn malformed_payload() -> anyhow::Result<()> {
 
     let prover_mock = &insertion_prover_map[&batch_size];
 
-    let port = db_container.port();
-    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
     let mut options = Options::try_parse_from([
         "signup-sequencer",
         "--identity-manager-address",

--- a/tests/multi_prover.rs
+++ b/tests/multi_prover.rs
@@ -38,8 +38,8 @@ async fn multi_prover() -> anyhow::Result<()> {
 
     info!("Running with {prover_arg_string}");
 
-    let port = db_container.port();
-    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
     let mut options = Options::try_parse_from([
         "signup-sequencer",
         "--identity-manager-address",

--- a/tests/recover_identities.rs
+++ b/tests/recover_identities.rs
@@ -44,8 +44,8 @@ async fn recover_identities() -> anyhow::Result<()> {
     let mock_insertion_prover = &insertion_prover_map[&insertion_batch_size];
     let mock_deletion_prover = &deletion_prover_map[&deletion_batch_size];
 
-    let port = db_container.port();
-    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
 
     let mut options = Options::try_parse_from([
         "signup-sequencer",

--- a/tests/unavailable_prover.rs
+++ b/tests/unavailable_prover.rs
@@ -23,8 +23,8 @@ async fn unavailable_prover() -> anyhow::Result<()> {
 
     prover_mock.set_availability(false).await;
 
-    let port = db_container.port();
-    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
     let mut options = Options::try_parse_from([
         "signup-sequencer",
         "--identity-manager-address",

--- a/tests/unreduced_identity.rs
+++ b/tests/unreduced_identity.rs
@@ -16,8 +16,8 @@ async fn test_unreduced_identity() -> anyhow::Result<()> {
     let prover_mock = &insertion_prover_map[&batch_size];
     prover_mock.set_availability(false).await;
 
-    let port = db_container.port();
-    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
     let mut options = Options::try_parse_from([
         "signup-sequencer",
         "--identity-manager-address",

--- a/tests/validate_proof_with_age.rs
+++ b/tests/validate_proof_with_age.rs
@@ -28,8 +28,8 @@ async fn validate_proof_with_age() -> anyhow::Result<()> {
 
     let prover_mock = &insertion_prover_map[&batch_size];
 
-    let port = db_container.port();
-    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
 
     let mut options = Options::try_parse_from([
         "signup-sequencer",

--- a/tests/validate_proofs.rs
+++ b/tests/validate_proofs.rs
@@ -26,8 +26,8 @@ async fn validate_proofs() -> anyhow::Result<()> {
 
     let identity_manager = mock_chain.identity_manager.clone();
 
-    let port = db_container.port();
-    let db_url = format!("postgres://postgres:postgres@localhost:{port}/database");
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
 
     let mut options = Options::try_parse_from([
         "signup-sequencer",


### PR DESCRIPTION
Changes the naive logic to `SocketAddr` parsing - we'll grab and use the first available socket address exposed by docker