### PR TITLE
convert leaf_index to ruint u256

### DIFF
--- a/schemas/database/001_init.sql
+++ b/schemas/database/001_init.sql
@@ -1,5 +1,5 @@
 CREATE TABLE identities (
-    leaf_index    BIGINT      NOT NULL PRIMARY KEY,
+    leaf_index    BYTEA       NOT NULL PRIMARY KEY,
     commitment    BYTEA       NOT NULL UNIQUE,
     root          BYTEA       NOT NULL UNIQUE,
     status        VARCHAR(50) NOT NULL,

--- a/schemas/database/004_identities.up.sql
+++ b/schemas/database/004_identities.up.sql
@@ -1,8 +1,15 @@
 -- Add the new 'id' column
 ALTER TABLE identities ADD COLUMN id BIGINT;
 
--- Populate 'id' with 'leaf_index'
-UPDATE identities SET id = leaf_index;
+-- Populate 'id' with 'leaf_index' (assuming the BYTEA value is in big-endian format)
+UPDATE identities SET id = get_byte(leaf_index, 7) + 
+                           get_byte(leaf_index, 6) * 256 +
+                           get_byte(leaf_index, 5) * 65536 + 
+                           get_byte(leaf_index, 4) * 16777216 + 
+                           get_byte(leaf_index, 3) * 4294967296 + 
+                           get_byte(leaf_index, 2) * 1099511627776 + 
+                           get_byte(leaf_index, 1) * 281474976710656 + 
+                           get_byte(leaf_index, 0) * 72057594037927936;
 
 -- Set the new 'id' column as NOT NULL
 ALTER TABLE identities ALTER COLUMN id SET NOT NULL;
@@ -22,8 +29,8 @@ ALTER TABLE identities ADD PRIMARY KEY (id);
 -- Create a new sequence manually
 CREATE SEQUENCE identities_id_seq;
 
--- Initialize a counter based on the max 'leaf_index' value
-SELECT setval('identities_id_seq', coalesce((SELECT MAX(leaf_index) FROM identities), 1));
+-- Initialize a counter based on the max 'id' value
+SELECT setval('identities_id_seq', coalesce((SELECT MAX(id) FROM identities), 1));
 
 -- Set default value of id to use the sequence
 ALTER TABLE identities ALTER COLUMN id SET DEFAULT nextval('identities_id_seq');

--- a/schemas/database/006_deletions.sql
+++ b/schemas/database/006_deletions.sql
@@ -1,4 +1,4 @@
 CREATE TABLE deletions (
-    leaf_index    BIGINT      NOT NULL PRIMARY KEY,
+    leaf_index    BYTEA       NOT NULL PRIMARY KEY,
     commitment    BYTEA       NOT NULL UNIQUE
 )


### PR DESCRIPTION

initial attempt at addressing the following TODO in the file `src/database/mod.rs`

```
// TODO: consider using a larger value than i64 for leaf index, ruint should
// have postgres compatibility for u256
```

please let me know if this is useful and I'll be happy to keep making progress on it

the approach I've taken is to store `leaf_index` as a `BYTEA` in the database, because a `BIGINT` would be too small

there are [some parts of the code](https://github.com/worldcoin/signup-sequencer/compare/main...smatthewenglish:u256-leaf-index#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R258) that use the value of `leaf_index` to set the size of/index into an array, which could create problems if the `U256` value of `leaf_index` is bigger than `usize`

very appreciative of any and all feedback

bullish on worldcoin! would love to help out this initiative 🙌