### PR TITLE
Dzejkop/identity-history

### DIFF
--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -379,8 +379,6 @@ impl IdentityManager {
         let packed_deletion_indices: &[u8] = delete_identities.packed_deletion_indices.as_ref();
         let indices = unpack_indices(packed_deletion_indices);
 
-        tracing::error!("unpacked = {indices:?}");
-
         let padding_index = 2u32.pow(self.tree_depth as u32);
 
         Ok(indices

--- a/src/database/types.rs
+++ b/src/database/types.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 
-use crate::identity_tree::{Hash, ProcessedStatus, Status, UnprocessedStatus};
+use crate::identity_tree::{Hash, Status, UnprocessedStatus};
 
 pub struct UnprocessedCommitment {
     pub commitment:            Hash,

--- a/src/database/types.rs
+++ b/src/database/types.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 
-use crate::identity_tree::{Hash, UnprocessedStatus};
+use crate::identity_tree::{Hash, ProcessedStatus, Status, UnprocessedStatus};
 
 pub struct UnprocessedCommitment {
     pub commitment:            Hash,
@@ -24,4 +24,14 @@ pub struct LatestDeletionEntry {
 pub struct DeletionEntry {
     pub leaf_index: usize,
     pub commitment: Hash,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct CommitmentHistoryEntry {
+    pub commitment: Hash,
+    pub leaf_index: Option<usize>,
+    // Only applies to buffered entries
+    // set to true if the eligibility timestamp is in the future
+    pub held_back:  bool,
+    pub status:     Status,
 }

--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -1,0 +1,250 @@
+use hyper::StatusCode;
+use semaphore::protocol::Proof;
+use semaphore::Field;
+use serde::{Deserialize, Serialize};
+
+use crate::identity_tree::{
+    Hash, InclusionProof, ProcessedStatus, RootItem, Status, UnprocessedStatus,
+};
+use crate::prover::{ProverConfiguration, ProverType};
+
+#[derive(Serialize)]
+#[serde(transparent)]
+pub struct InclusionProofResponse(pub InclusionProof);
+
+#[derive(Serialize)]
+#[serde(transparent)]
+pub struct ListBatchSizesResponse(pub Vec<ProverConfiguration>);
+
+#[derive(Serialize)]
+#[serde(transparent)]
+pub struct VerifySemaphoreProofResponse(pub RootItem);
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct IdentityHistoryResponse {
+    pub history: Vec<IdentityHistoryEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct IdentityHistoryEntry {
+    pub kind:   IdentityHistoryEntryKind,
+    pub status: IdentityHistoryEntryStatus,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub enum IdentityHistoryEntryKind {
+    Insertion,
+    Deletion,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub enum IdentityHistoryEntryStatus {
+    // Present in the unprocessed identities or deletions table
+    Buffered,
+    // Present in the unprocessed identities table but not eligible for processing
+    Queued,
+    // Present in the pending tree (not mined on chain yet)
+    Pending,
+    // Present in the batching tree (transaction sent but not confirmed yet)
+    Batched,
+    // Present in the processed tree (mined on chain)
+    Mined,
+    // Present in the batching tree (mined on chain)
+    Bridged,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct InsertCommitmentRequest {
+    pub identity_commitment: Hash,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct AddBatchSizeRequest {
+    /// The URL of the prover for the provided batch size.
+    pub url:             String,
+    /// The batch size to add.
+    pub batch_size:      usize,
+    /// The timeout for communications with the prover service.
+    pub timeout_seconds: u64,
+    // TODO: add docs
+    pub prover_type:     ProverType,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct RemoveBatchSizeRequest {
+    /// The batch size to remove from the prover map.
+    pub batch_size:  usize,
+    // TODO: add docs
+    pub prover_type: ProverType,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct InclusionProofRequest {
+    pub identity_commitment: Hash,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct IdentityHistoryRequest {
+    pub identity_commitment: Hash,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct VerifySemaphoreProofRequest {
+    pub root:                    Field,
+    pub signal_hash:             Field,
+    pub nullifier_hash:          Field,
+    pub external_nullifier_hash: Field,
+    pub proof:                   Proof,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct VerifySemaphoreProofQuery {
+    #[serde(default)]
+    pub max_root_age_seconds: Option<i64>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct DeletionRequest {
+    /// The identity commitment to delete.
+    pub identity_commitment: Hash,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct RecoveryRequest {
+    /// The leaf index of the identity commitment to delete.
+    pub previous_identity_commitment: Hash,
+    /// The new identity commitment to insert.
+    pub new_identity_commitment:      Hash,
+}
+
+impl InclusionProofResponse {
+    #[must_use]
+    pub fn hide_processed_status(mut self) -> Self {
+        self.0.status = if self.0.status == Status::Processed(ProcessedStatus::Processed) {
+            Status::Processed(ProcessedStatus::Pending)
+        } else {
+            self.0.status
+        };
+
+        self
+    }
+}
+
+impl From<InclusionProof> for InclusionProofResponse {
+    fn from(value: InclusionProof) -> Self {
+        Self(value)
+    }
+}
+
+impl ToResponseCode for InclusionProofResponse {
+    fn to_response_code(&self) -> StatusCode {
+        match self.0.status {
+            Status::Unprocessed(UnprocessedStatus::Failed) => StatusCode::BAD_REQUEST,
+            Status::Unprocessed(UnprocessedStatus::New)
+            | Status::Processed(ProcessedStatus::Pending) => StatusCode::ACCEPTED,
+            Status::Processed(ProcessedStatus::Mined | ProcessedStatus::Processed) => {
+                StatusCode::OK
+            }
+        }
+    }
+}
+
+impl From<Vec<ProverConfiguration>> for ListBatchSizesResponse {
+    fn from(value: Vec<ProverConfiguration>) -> Self {
+        Self(value)
+    }
+}
+
+impl ToResponseCode for ListBatchSizesResponse {
+    fn to_response_code(&self) -> StatusCode {
+        StatusCode::OK
+    }
+}
+
+impl VerifySemaphoreProofResponse {
+    #[must_use]
+    pub fn hide_processed_status(mut self) -> Self {
+        self.0.status = if self.0.status == ProcessedStatus::Processed {
+            ProcessedStatus::Pending
+        } else {
+            self.0.status
+        };
+
+        self
+    }
+}
+
+impl ToResponseCode for VerifySemaphoreProofResponse {
+    fn to_response_code(&self) -> StatusCode {
+        StatusCode::OK
+    }
+}
+
+impl IdentityHistoryEntryKind {
+    pub fn is_insertion(&self) -> bool {
+        matches!(self, IdentityHistoryEntryKind::Insertion)
+    }
+
+    pub fn is_deletion(&self) -> bool {
+        matches!(self, IdentityHistoryEntryKind::Deletion)
+    }
+}
+
+pub trait ToResponseCode {
+    fn to_response_code(&self) -> StatusCode;
+}
+
+impl ToResponseCode for () {
+    fn to_response_code(&self) -> StatusCode {
+        StatusCode::OK
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_history_entry_status_ordering() {
+        let expected = vec![
+            IdentityHistoryEntryStatus::Buffered,
+            IdentityHistoryEntryStatus::Queued,
+            IdentityHistoryEntryStatus::Pending,
+            IdentityHistoryEntryStatus::Batched,
+            IdentityHistoryEntryStatus::Mined,
+            IdentityHistoryEntryStatus::Bridged,
+        ];
+
+        let mut statuses = expected.clone();
+
+        statuses.sort();
+
+        assert_eq!(expected, statuses);
+    }
+}

--- a/tests/identity_history.rs
+++ b/tests/identity_history.rs
@@ -1,0 +1,340 @@
+mod common;
+
+use common::prelude::*;
+use hyper::StatusCode;
+use signup_sequencer::server::data::{
+    IdentityHistoryEntryStatus, IdentityHistoryRequest, IdentityHistoryResponse,
+};
+
+use crate::common::test_recover_identity;
+
+const SUPPORTED_DEPTH: usize = 18;
+
+const HISTORY_POLLING_SLEEP: Duration = Duration::from_secs(5);
+const MAX_HISTORY_POLLING_ATTEMPTS: usize = 24; // 2 minutes
+
+#[tokio::test]
+async fn identity_history() -> anyhow::Result<()> {
+    // Initialize logging for the test.
+    init_tracing_subscriber();
+    info!("Starting integration test");
+
+    let insertion_batch_size: usize = 8;
+    let deletion_batch_size: usize = 3;
+    let batch_deletion_timeout_seconds: usize = 10;
+
+    #[allow(clippy::cast_possible_truncation)]
+    let tree_depth: u8 = SUPPORTED_DEPTH as u8;
+
+    let mut ref_tree = PoseidonTree::new(SUPPORTED_DEPTH + 1, ruint::Uint::ZERO);
+    let initial_root: U256 = ref_tree.root().into();
+
+    let (mock_chain, db_container, insertion_prover_map, deletion_prover_map, micro_oz) =
+        spawn_deps(
+            initial_root,
+            &[insertion_batch_size],
+            &[deletion_batch_size],
+            tree_depth,
+        )
+        .await?;
+
+    // Set the root history expirty to 30 seconds
+    let updated_root_history_expiry = U256::from(30);
+    mock_chain
+        .identity_manager
+        .method::<_, ()>("setRootHistoryExpiry", updated_root_history_expiry)?
+        .send()
+        .await?
+        .await?;
+
+    let mock_insertion_prover = &insertion_prover_map[&insertion_batch_size];
+    let mock_deletion_prover = &deletion_prover_map[&deletion_batch_size];
+
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
+
+    let temp_dir = tempfile::tempdir()?;
+    info!(
+        "temp dir created at: {:?}",
+        temp_dir.path().join("testfile")
+    );
+
+    let mut options = Options::try_parse_from([
+        "signup-sequencer",
+        "--identity-manager-address",
+        "0x0000000000000000000000000000000000000000", // placeholder, updated below
+        "--database",
+        &db_url,
+        "--database-max-connections",
+        "1",
+        "--tree-depth",
+        &format!("{tree_depth}"),
+        "--prover-urls",
+        &format!(
+            "[{}, {}]",
+            mock_insertion_prover.arg_string_single(),
+            mock_deletion_prover.arg_string_single()
+        ),
+        "--batch-timeout-seconds",
+        "10",
+        "--batch-deletion-timeout-seconds",
+        &format!("{batch_deletion_timeout_seconds}"),
+        "--min-batch-deletion-size",
+        &format!("{deletion_batch_size}"),
+        "--dense-tree-prefix-depth",
+        "10",
+        "--tree-gc-threshold",
+        "1",
+        "--oz-api-key",
+        "",
+        "--oz-api-secret",
+        "",
+        "--oz-api-url",
+        &micro_oz.endpoint(),
+        "--oz-address",
+        &format!("{:?}", micro_oz.address()),
+        "--dense-tree-mmap-file",
+        temp_dir.path().join("testfile").to_str().unwrap(),
+    ])
+    .context("Failed to create options")?;
+
+    options.server.server = Url::parse("http://127.0.0.1:0/").expect("Failed to parse URL");
+
+    options.app.contracts.identity_manager_address = mock_chain.identity_manager.address();
+    options.app.ethereum.ethereum_provider =
+        Url::parse(&mock_chain.anvil.endpoint()).expect("Failed to parse Anvil url");
+
+    let (app, local_addr) = spawn_app(options.clone())
+        .await
+        .expect("Failed to spawn app.");
+
+    let test_identities = generate_test_identities(insertion_batch_size * 3);
+    let identities_ref: Vec<Field> = test_identities
+        .iter()
+        .map(|i| Hash::from_str_radix(i, 16).unwrap())
+        .collect();
+
+    let uri = "http://".to_owned() + &local_addr.to_string();
+    let client = Client::new();
+
+    let mut next_leaf_index = 0;
+    // Insert enough identities to trigger an batch to be sent to the blockchain.
+    for i in 0..insertion_batch_size {
+        test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, i).await;
+
+        next_leaf_index += 1;
+    }
+
+    poll_history_until(
+        &uri,
+        &client,
+        &identities_ref[0],
+        |history| {
+            history.history[0].kind.is_insertion()
+                && history.history[0].status >= IdentityHistoryEntryStatus::Buffered
+        },
+        "Polling until first insertion is buffered",
+    )
+    .await?;
+
+    poll_history_until(
+        &uri,
+        &client,
+        &identities_ref[0],
+        |history| {
+            history.history[0].kind.is_insertion()
+                && history.history[0].status >= IdentityHistoryEntryStatus::Pending
+        },
+        "Polling until first insertion is pending",
+    )
+    .await?;
+
+    poll_history_until(
+        &uri,
+        &client,
+        &identities_ref[0],
+        |history| {
+            history.history[0].kind.is_insertion()
+                && history.history[0].status >= IdentityHistoryEntryStatus::Batched
+        },
+        "Polling until first insertion is batched",
+    )
+    .await?;
+
+    poll_history_until(
+        &uri,
+        &client,
+        &identities_ref[0],
+        |history| {
+            history.history[0].kind.is_insertion()
+                && history.history[0].status >= IdentityHistoryEntryStatus::Bridged
+        },
+        "Polling until first insertion is mined/bridged",
+    )
+    .await?;
+
+    // Insert enough recoveries to trigger a batch
+    for i in 0..deletion_batch_size {
+        // Delete the identity at i and replace it with an identity at the back of the
+        //  test identities array
+        // TODO: we should update to a much cleaner approach
+        let recovery_leaf_index = test_identities.len() - i - 1;
+
+        test_recover_identity(
+            &uri,
+            &client,
+            &mut ref_tree,
+            &identities_ref,
+            i,
+            identities_ref[recovery_leaf_index],
+            next_leaf_index,
+            false,
+        )
+        .await;
+
+        next_leaf_index += 1;
+    }
+
+    let sample_recovery_identity = test_identities.len() - 1;
+
+    tracing::info!("############ Deletion should be buffered ############");
+    poll_history_until(
+        &uri,
+        &client,
+        &identities_ref[0],
+        |history| {
+            history.history[0].kind.is_insertion()
+                && history.history[0].status >= IdentityHistoryEntryStatus::Bridged
+                && history.history[1].kind.is_deletion()
+                && history.history[1].status >= IdentityHistoryEntryStatus::Buffered
+        },
+        "Polling until first deletion is buffered",
+    )
+    .await?;
+
+    tracing::info!("############ Recovery should be queued ############");
+    poll_history_until(
+        &uri,
+        &client,
+        &identities_ref[sample_recovery_identity],
+        |history| {
+            !history.history.is_empty()
+                && history.history[0].kind.is_insertion()
+                && history.history[0].status >= IdentityHistoryEntryStatus::Queued
+        },
+        "Polling until first recovery is queued",
+    )
+    .await?;
+
+    // Eventually the old identity will be deleted
+    tracing::info!("############ Waiting for deletion to be mined/bridged ############");
+    poll_history_until(
+        &uri,
+        &client,
+        &identities_ref[0],
+        |history| {
+            history.history[0].kind.is_insertion()
+                && history.history[0].status >= IdentityHistoryEntryStatus::Bridged
+                && history.history[1].kind.is_deletion()
+                && history.history[1].status >= IdentityHistoryEntryStatus::Bridged
+        },
+        "Polling until first deletion is mined/bridged",
+    )
+    .await?;
+
+    // Sleep for root expiry
+    tokio::time::sleep(Duration::from_secs(updated_root_history_expiry.as_u64())).await;
+
+    // Insert enough identities to trigger an batch to be sent to the blockchain.
+    for i in insertion_batch_size..insertion_batch_size * 2 {
+        test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, i).await;
+        next_leaf_index += 1;
+    }
+
+    tracing::info!("############ Final wait ############");
+    poll_history_until(
+        &uri,
+        &client,
+        &identities_ref[sample_recovery_identity],
+        |history| {
+            history.history[0].kind.is_insertion()
+                && history.history[0].status >= IdentityHistoryEntryStatus::Bridged
+        },
+        "Polling until recovery is mined/bridged",
+    )
+    .await?;
+
+    // Shutdown the app properly for the final time
+    shutdown();
+    app.await.unwrap();
+    for (_, prover) in insertion_prover_map.into_iter() {
+        prover.stop();
+    }
+    for (_, prover) in deletion_prover_map.into_iter() {
+        prover.stop();
+    }
+    reset_shutdown();
+
+    Ok(())
+}
+
+async fn poll_history_until(
+    uri: &str,
+    client: &Client<HttpConnector>,
+    identity: &Field,
+    predicate: impl Fn(&IdentityHistoryResponse) -> bool,
+    label: &str,
+) -> anyhow::Result<()> {
+    for _ in 0..MAX_HISTORY_POLLING_ATTEMPTS {
+        if let Some(history) = fetch_identity_history(uri, client, identity, label).await? {
+            if predicate(&history) {
+                return Ok(());
+            } else {
+                tracing::warn!("Label {label} - history {history:?} does not match predicate");
+            }
+        } else {
+            tracing::warn!("No identity history for label {label}");
+        }
+
+        tokio::time::sleep(HISTORY_POLLING_SLEEP).await;
+    }
+
+    anyhow::bail!("Failed to fetch identity history within max attempts - {label}")
+}
+
+async fn fetch_identity_history(
+    uri: &str,
+    client: &Client<HttpConnector>,
+    identity: &Field,
+    label: &str,
+) -> anyhow::Result<Option<IdentityHistoryResponse>> {
+    let uri = format!("{uri}/identityHistory");
+    let body = IdentityHistoryRequest {
+        identity_commitment: identity.clone(),
+    };
+
+    let req = Request::post(uri)
+        .header("Content-Type", "application/json")
+        .body(Body::from(serde_json::to_string(&body)?))?;
+
+    let mut response = client.request(req).await?;
+
+    match response.status() {
+        StatusCode::NOT_FOUND => return Ok(None),
+        otherwise if otherwise.is_success() => {
+            // continue
+        }
+        status => {
+            anyhow::bail!("Failed to fetch identity history - status was {status} - label {label}")
+        }
+    }
+
+    let body_bytes = hyper::body::to_bytes(response.body_mut()).await?;
+    let body_bytes = body_bytes.to_vec();
+
+    let body_string = String::from_utf8(body_bytes)?;
+
+    let response: IdentityHistoryResponse = serde_json::from_str(&body_string)?;
+
+    Ok(Some(response))
+}


### PR DESCRIPTION
A feature for deletion/recovery

The purpose is to provide a detailed history view into a given identity. Format of the history response is the following
```json
{
  "history": [
    { "kind": "insertion", "status": "buffered" }
  ]
}
```

Where:
1. There can be at most 2 entries in the history (1 for insertion, 1 for deletion)
2. Kind can be `insertion` or `deletion`
3. Status can be `bufferd`, `queued`, `pending`, `batched`, `mined`, `bridged` - for more info look into `IdentityHistoryEntryStatus` in `src/app.rs` 