### PR TITLE
Remove `UnprocessedStatus::Failed`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -443,6 +443,8 @@ impl App {
             return Err(ServerError::UnreducedCommitment);
         }
 
+        // TODO: ensure that the id is not in the tree or in unprocessed identities
+
         if self.database.identity_exists(commitment).await? {
             return Err(ServerError::DuplicateCommitment);
         }
@@ -581,10 +583,6 @@ impl App {
                 Status::Processed(ProcessedStatus::Processed) => IdentityHistoryEntryStatus::Mined,
                 Status::Processed(ProcessedStatus::Mined) => IdentityHistoryEntryStatus::Bridged,
                 Status::Unprocessed(UnprocessedStatus::New) => IdentityHistoryEntryStatus::Buffered,
-                // This status virtually never happens so we'll mark it as buffered
-                Status::Unprocessed(UnprocessedStatus::Failed) => {
-                    IdentityHistoryEntryStatus::Buffered
-                }
             };
 
             match status {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -864,26 +864,6 @@ impl Database {
         Ok(())
     }
 
-    pub async fn update_err_unprocessed_commitment(
-        &self,
-        commitment: Hash,
-        message: String,
-    ) -> Result<(), Error> {
-        let query = sqlx::query(
-            r#"
-                UPDATE unprocessed_identities SET error_message = $1, status = $2
-                WHERE commitment = $3
-            "#,
-        )
-        .bind(message)
-        .bind(<&str>::from(UnprocessedStatus::Failed))
-        .bind(commitment);
-
-        self.pool.execute(query).await?;
-
-        Ok(())
-    }
-
     pub async fn identity_exists(&self, commitment: Hash) -> Result<bool, Error> {
         let query_unprocessed_identity = sqlx::query(
             r#"SELECT exists(SELECT 1 FROM unprocessed_identities where commitment = $1)"#,

--- a/src/identity_tree/status.rs
+++ b/src/identity_tree/status.rs
@@ -31,11 +31,6 @@ pub enum ProcessedStatus {
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum UnprocessedStatus {
-    /// Unprocessed identity failed to be inserted into the tree for some reason
-    ///
-    /// Usually accompanied by an appropriate error message
-    Failed,
-
     /// Root is unprocessed - i.e. not included in sequencer's
     /// in-memory tree.
     New,
@@ -98,7 +93,6 @@ impl FromStr for UnprocessedStatus {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "new" => Ok(Self::New),
-            "failed" => Ok(Self::Failed),
             _ => Err(UnknownStatus),
         }
     }
@@ -108,7 +102,6 @@ impl From<UnprocessedStatus> for &str {
     fn from(scope: UnprocessedStatus) -> Self {
         match scope {
             UnprocessedStatus::New => "new",
-            UnprocessedStatus::Failed => "failed",
         }
     }
 }
@@ -134,7 +127,6 @@ mod tests {
     #[test_case(Status::Processed(ProcessedStatus::Pending) => "pending")]
     #[test_case(Status::Processed(ProcessedStatus::Mined) => "mined")]
     #[test_case(Status::Unprocessed(UnprocessedStatus::New) => "new")]
-    #[test_case(Status::Unprocessed(UnprocessedStatus::Failed) => "failed")]
     fn serialize_status(api_status: Status) -> &'static str {
         let s = serde_json::to_string(&api_status).unwrap();
 
@@ -147,7 +139,6 @@ mod tests {
     #[test_case("pending" => Status::Processed(ProcessedStatus::Pending))]
     #[test_case("mined" => Status::Processed(ProcessedStatus::Mined))]
     #[test_case("new" => Status::Unprocessed(UnprocessedStatus::New))]
-    #[test_case("failed" => Status::Unprocessed(UnprocessedStatus::Failed))]
     fn deserialize_status(s: &str) -> Status {
         // Wrapped because JSON expected `"something"` and not `something`
         let wrapped = format!("\"{s}\"");

--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -165,7 +165,6 @@ impl From<InclusionProof> for InclusionProofResponse {
 impl ToResponseCode for InclusionProofResponse {
     fn to_response_code(&self) -> StatusCode {
         match self.0.status {
-            Status::Unprocessed(UnprocessedStatus::Failed) => StatusCode::BAD_REQUEST,
             Status::Unprocessed(UnprocessedStatus::New)
             | Status::Processed(ProcessedStatus::Pending) => StatusCode::ACCEPTED,
             Status::Processed(ProcessedStatus::Mined | ProcessedStatus::Processed) => {

--- a/src/task_monitor/tasks/insert_identities.rs
+++ b/src/task_monitor/tasks/insert_identities.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/src/task_monitor/tasks/insert_identities.rs
+++ b/src/task_monitor/tasks/insert_identities.rs
@@ -66,8 +66,8 @@ async fn insert_identities(
     for identity in identities {
         if database
             .get_identity_leaf_index(&identity.commitment)
-            .await
-            .is_ok()
+            .await?
+            .is_some()
         {
             tracing::warn!(?identity.commitment, "Duplicate identity");
             database

--- a/src/task_monitor/tasks/insert_identities.rs
+++ b/src/task_monitor/tasks/insert_identities.rs
@@ -8,7 +8,7 @@ use tracing::instrument;
 
 use crate::database::types::UnprocessedCommitment;
 use crate::database::Database;
-use crate::identity_tree::{Hash, Latest, TreeVersion, TreeVersionReadOps, UnprocessedStatus};
+use crate::identity_tree::{Latest, TreeVersion, TreeVersionReadOps, UnprocessedStatus};
 
 pub struct InsertIdentities {
     database:       Arc<Database>,

--- a/src/task_monitor/tasks/insert_identities.rs
+++ b/src/task_monitor/tasks/insert_identities.rs
@@ -62,43 +62,6 @@ async fn insert_identities(
     latest_tree: &TreeVersion<Latest>,
     identities: Vec<UnprocessedCommitment>,
 ) -> AnyhowResult<()> {
-    // Dedup
-    let mut commitments_set = HashSet::new();
-    let mut deduped = Vec::with_capacity(identities.len());
-
-    for identity in identities {
-        if commitments_set.contains(&identity.commitment) {
-            database
-                .update_err_unprocessed_commitment(
-                    identity.commitment,
-                    "Duplicate commitment.".into(),
-                )
-                .await?;
-        } else {
-            commitments_set.insert(identity.commitment);
-            deduped.push(identity);
-        }
-    }
-
-    // Validate the identities are not in the database
-    let mut identities = Vec::with_capacity(deduped.len());
-    for identity in deduped {
-        if database
-            .get_identity_leaf_index(&identity.commitment)
-            .await?
-            .is_some()
-        {
-            database
-                .update_err_unprocessed_commitment(
-                    identity.commitment,
-                    "Duplicate commitment.".into(),
-                )
-                .await?;
-        } else {
-            identities.push(identity);
-        }
-    }
-
     let next_db_index = database.get_next_leaf_index().await?;
     let next_leaf = latest_tree.next_leaf();
 


### PR DESCRIPTION
This PR removes the `Failed` variant from the `UnprocessedStatus` enum. 

While this PR does not remove the `UnprocessedStatus` enum entirely, it seems that `Unprocessed` could be combined with the `ProcessedStatus` variants to have one cohesive `Status` enum ([link for reference](https://github.com/worldcoin/signup-sequencer/blob/main/src/identity_tree/status.rs#L10-L52)).

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
