### PR TITLE
Defer tree initialization PRO-498

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,8 @@ once_cell = "1.8"
 oz-api = { path = "crates/oz-api" }
 prometheus = "0.13.3" # We need upstream PR#465 to fix #272.
 reqwest = { version = "0.11.18", features = ["json"] }
-ruint = { version = "1.3", features = ["primitive-types", "sqlx"] }
+# ruint has broken semver, specify exact version.
+ruint = { version = "=1.7", features = ["primitive-types", "sqlx"] }
 semaphore = { git = "https://github.com/worldcoin/semaphore-rs", branch = "main", features = [
     "depth_30",
 ] }

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,3 @@
-
 ![lines of code](https://img.shields.io/tokei/lines/github/worldcoin/signup-sequencer)
 [![dependency status](https://deps.rs/repo/github/worldcoin/signup-sequencer/status.svg)](https://deps.rs/repo/github/worldcoin/signup-sequencer)
 [![CI](https://github.com/worldcoin/signup-sequencer/actions/workflows/test.yml/badge.svg)](https://github.com/worldcoin/signup-sequencer/actions/workflows/test.yml)
@@ -9,6 +8,7 @@
 Sign-up Sequencer does sequencing of data (identities) that are committed in a batch to an Ethereum Smart Contract.
 
 ## Table of Contents
+
 1. [Introduction](#introduction)
 2. [Getting Started](#getting-started)
 3. [Tests](#tests)
@@ -19,33 +19,33 @@ Sign-up Sequencer does sequencing of data (identities) that are committed in a b
 Sequencer has 6 API routes.
 
 1. `/insertIdentity` - Accepts identity commitment hash as input which gets added in queue for processing.
-    Identities go through three tasks.
+   Identities go through three tasks.
     1. Insertion: In the initial stage, the identities are placed into the Sequencer's database.
-    The database is polled every few seconds and added to insertion task.
-    2. Processing: The processing of identities, where current batching tree is taken and processed so we 
-    end up with pre root (the root of tree before proofs are generated), post root, start index and
-    identity commitments (with their proofs). All of those get sent to a [prover](#semaphore-mtb) for proof generation.
-    The identities transaction is then mined, with aforementioned fields and pending identities are sent to task to be mined on-chain.
-    3. Mining:  The transaction ID from processing task gets mined and Sequencer database gets updated accordingly.
-    Now with blockchain and database being in sync, the mined tree gets updated as well.
+       The database is polled every few seconds and added to insertion task.
+    2. Processing: The processing of identities, where current batching tree is taken and processed so we
+       end up with pre root (the root of tree before proofs are generated), post root, start index and
+       identity commitments (with their proofs). All of those get sent to a [prover](#semaphore-mtb) for proof generation.
+       The identities transaction is then mined, with aforementioned fields and pending identities are sent to task to be mined on-chain.
+    3. Mining: The transaction ID from processing task gets mined and Sequencer database gets updated accordingly.
+       Now with blockchain and database being in sync, the mined tree gets updated as well.
 2. `/inclusionProof` - Takes the identity commitment hash, and checks for any errors that might have occurred in the insert identity steps.
-    Then leaf index is fetched from the database, corresponding to the identity hash provided, and then we check if the identity is
-    indeed in the tree. The inclusion proof is then returned to the API caller.
+   Then leaf index is fetched from the database, corresponding to the identity hash provided, and then we check if the identity is
+   indeed in the tree. The inclusion proof is then returned to the API caller.
 3. `/deleteIdentity` - Takes an identity commitment hash, ensures that it exists and hasn't been deleted yet. This identity is then scheduled for deletion.
 4. `/recoverIdentity` - Takes two identity commitment hashes. The first must exist and will be scheduled for deletion and the other will be inserted as a replacement after the first identity has been deleted and a set amount of time (depends on configuration parameters) has passed.
 5. `/verifySemaphoreProof` - This call takes root, signal hash, nullifier hash, external nullifier hash and a proof.
-    The proving key is fetched based on the depth index, and verification key as well.
-    The list of prime fields is created based on request input mentioned before, and then we proceed to verify the proof.
-    Sequencer uses groth16 zk-SNARK implementation.
-    The API call returns the proof as a response.
-6.  `/addBatchSize` - Adds a prover with specific batch size to a list of provers.
-7.  `/removeBatchSize` - Removes the prover based on batch size.
-8.  `/listBatchSizes` - Lists all provers that are added to the Sequencer.
-
-
+   The proving key is fetched based on the depth index, and verification key as well.
+   The list of prime fields is created based on request input mentioned before, and then we proceed to verify the proof.
+   Sequencer uses groth16 zk-SNARK implementation.
+   The API call returns the proof as a response.
+6. `/addBatchSize` - Adds a prover with specific batch size to a list of provers.
+7. `/removeBatchSize` - Removes the prover based on batch size.
+8. `/listBatchSizes` - Lists all provers that are added to the Sequencer.
 
 ## Getting Started
+
 ### (Local development)
+
 Install Protobuf compiler
 
 | Os            | Command                                     |
@@ -62,6 +62,7 @@ docker pull postgres
 ```
 
 ### Worldcoin id contracts
+
 Worldcoin id contracts are ethereum smart contracts that are used by the sequencer
 
 Clone [worldcoin id contracts](https://github.com/worldcoin/world-id-contracts) and execute `make build && npm install`
@@ -73,12 +74,14 @@ Make sure you use a private key from your local ethereum network account.
 !! Make a note of all the addresses generated by the script !!
 
 ### Semaphore-mtb
+
 Semaphore-mtb is a service for batch processing of Merkle tree updates.
 
 Clone [semaphore-mtb](https://github.com/worldcoin/semaphore-mtb) and execute `go build .` (you will need a golang compiler)
 
-Go build will create an executable named gnark-mbu.  If you went through the worldcoin id contracts deploy script,
+Go build will create an executable named gnark-mbu. If you went through the worldcoin id contracts deploy script,
 you will have a generated keys file that is used by semaphore-mtb.
+
 ```shell
 ./gnark-mbu start --keys-file path/to/world-id-contracts/mtb/keys
 ```
@@ -90,6 +93,7 @@ docker run --rm -ti -p 5432:5432 -e POSTGRES_PASSWORD=password postgres
 ```
 
 Now you are ready to start up sequencer service!
+
 ```shell
 TREE_DEPTH=*your tree depth (eg. 16)* cargo run -- --batch-size *batch size for semaphore-mtb (eg. 3)* --batch-timeout-seconds 10 --database postgres://postgres:password@0.0.0.0:5432 --identity-manager-address *address from worldcoin id contracts identity manager*
 --signing-key *private key you used to deploy smart contracts*
@@ -98,6 +102,8 @@ TREE_DEPTH=*your tree depth (eg. 16)* cargo run -- --batch-size *batch size for 
 ## Tests
 
 Lint, build, test
+
+First ensure you have the docker daemon up and running, then:
 
 ```shell
 cargo fmt && cargo clippy --all-targets && cargo build --all-targets && cargo test --all-targets

--- a/crates/postgres-docker-utils/src/lib.rs
+++ b/crates/postgres-docker-utils/src/lib.rs
@@ -92,7 +92,7 @@ fn parse_exposed_port(s: &str) -> anyhow::Result<SocketAddr> {
         .iter()
         .map(|p| p.parse::<SocketAddr>())
         .next()
-        .context("Missing exposed port")??)
+        .context("Missing exposed port, is your docker daemon running?")??)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ async fn sequencer_app(args: Args) -> anyhow::Result<()> {
     let task_monitor = TaskMonitor::new(app.clone());
 
     // Process to push new identities to Ethereum
-    tokio::spawn(task_monitor.clone().start());
+    task_monitor.start().await;
 
     // Start server (will stop on shutdown signal)
     server::run(app, server_config).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 #![allow(clippy::module_name_repetitions, clippy::wildcard_imports)]
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use clap::Parser;
 use cli_batteries::{run, version};
@@ -40,16 +39,15 @@ async fn sequencer_app(args: Args) -> anyhow::Result<()> {
     let server_config = config.server.clone();
 
     // Create App struct
-    let app = Arc::new(App::new(config).await?);
-    let app_for_server = app.clone();
+    let app = App::new(config).await?;
 
-    let task_monitor = TaskMonitor::new(app);
+    let task_monitor = TaskMonitor::new(app.clone());
 
     // Process to push new identities to Ethereum
-    task_monitor.start().await;
+    tokio::spawn(task_monitor.clone().start());
 
     // Start server (will stop on shutdown signal)
-    server::run(app_for_server, server_config).await?;
+    server::run(app, server_config).await?;
 
     tracing::info!("Stopping the app");
     task_monitor.shutdown().await?;

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -63,6 +63,8 @@ pub enum Error {
     NoProversOnIdInsert,
     #[error("Identity Manager had no provers on point of identity deletion.")]
     NoProversOnIdDeletion,
+    #[error("The tree is uninitialized. Try again in a few moments.")]
+    TreeStateUninitialized,
     #[error(transparent)]
     Other(#[from] EyreError),
 }

--- a/src/task_monitor.rs
+++ b/src/task_monitor.rs
@@ -78,15 +78,15 @@ pub struct TaskMonitor {
 }
 
 impl TaskMonitor {
-    pub fn new(app: Arc<App>) -> Arc<Self> {
-        Arc::new(Self {
+    pub fn new(app: Arc<App>) -> Self {
+        Self {
             instance: RwLock::new(None),
             app,
-        })
+        }
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub async fn start(self: Arc<Self>) {
+    pub async fn start(&self) {
         let mut instance = self.instance.write().await;
         if instance.is_some() {
             warn!("Identity committer already running");

--- a/src/task_monitor/tasks/delete_identities.rs
+++ b/src/task_monitor/tasks/delete_identities.rs
@@ -40,7 +40,7 @@ pub async fn delete_identities(app: Arc<App>, wake_up_notify: Arc<Notify>) -> an
 
             // Delete the commitments at the target leaf indices in the latest tree,
             // generating the proof for each update
-            let data = app.tree_state.latest_tree().delete_many(&leaf_indices);
+            let data = app.tree_state()?.latest_tree().delete_many(&leaf_indices);
 
             assert_eq!(
                 data.len(),

--- a/src/task_monitor/tasks/finalize_identities.rs
+++ b/src/task_monitor/tasks/finalize_identities.rs
@@ -40,7 +40,7 @@ pub async fn finalize_roots(app: Arc<App>) -> anyhow::Result<()> {
         finalize_mainnet_roots(
             &app.database,
             &app.identity_manager,
-            app.tree_state.processed_tree(),
+            app.tree_state()?.processed_tree(),
             &mainnet_logs,
             app.config.app.max_epoch_duration,
         )
@@ -52,7 +52,7 @@ pub async fn finalize_roots(app: Arc<App>) -> anyhow::Result<()> {
         finalize_secondary_roots(
             &app.database,
             &app.identity_manager,
-            app.tree_state.mined_tree(),
+            app.tree_state()?.mined_tree(),
             roots,
         )
         .await?;

--- a/src/task_monitor/tasks/insert_identities.rs
+++ b/src/task_monitor/tasks/insert_identities.rs
@@ -22,7 +22,8 @@ pub async fn insert_identities(app: Arc<App>, wake_up_notify: Arc<Notify>) -> an
             continue;
         }
 
-        insert_identities_batch(&app.database, app.tree_state.latest_tree(), unprocessed).await?;
+        insert_identities_batch(&app.database, app.tree_state()?.latest_tree(), unprocessed)
+            .await?;
         // Notify the identity processing task, that there are new identities
         wake_up_notify.notify_one();
     }

--- a/src/task_monitor/tasks/process_identities.rs
+++ b/src/task_monitor/tasks/process_identities.rs
@@ -66,7 +66,7 @@ pub async fn process_identities(
             },
         }
 
-        let Some(batch_type) = determine_batch_type(app.tree_state.batching_tree()) else {
+        let Some(batch_type) = determine_batch_type(app.tree_state()?.batching_tree()) else {
             continue;
         };
 
@@ -76,7 +76,10 @@ pub async fn process_identities(
             app.identity_manager.max_insertion_batch_size().await
         };
 
-        let updates = app.tree_state.batching_tree().peek_next_updates(batch_size);
+        let updates = app
+            .tree_state()?
+            .batching_tree()
+            .peek_next_updates(batch_size);
 
         let current_time = Utc::now();
         let batch_insertion_timeout =
@@ -101,7 +104,7 @@ pub async fn process_identities(
 
         commit_identities(
             &app.identity_manager,
-            app.tree_state.batching_tree(),
+            app.tree_state()?.batching_tree(),
             &monitored_txs_sender,
             &updates,
         )

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -67,7 +67,6 @@ pub mod prelude {
 use std::collections::HashMap;
 use std::net::{SocketAddr, TcpListener};
 use std::str::FromStr;
-use std::sync::Arc;
 
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -591,7 +590,6 @@ fn construct_verify_proof_body(
 pub async fn spawn_app(config: Config) -> anyhow::Result<(JoinHandle<()>, SocketAddr)> {
     let server_config = config.server.clone();
     let app = App::new(config).await.expect("Failed to create App");
-    let app = Arc::new(app);
 
     let task_monitor = TaskMonitor::new(app.clone());
 


### PR DESCRIPTION
This is a first draft of deferring tree initialization. I have some open TODOs here that I would like some feedback on.

1. different versions of `Duration` are being used in different places. Is this intended? from `chrono` and `std`. 
2. We need to delay `TaskManager::start` until after the tree initialization. It's not clear what the best way to do this is. Multiple routes we could take.
3. How should we handle the shutdown channel for `spawn_monitored_with_backoff`