### PR TITLE
Use testcontainers to run postgres database. Disable shutdown tests due to interfering tests (global var impl).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard-stubs"
+version = "1.42.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
+dependencies = [
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,12 +1763,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.5",
+ "darling_macro 0.20.5",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1776,11 +1810,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.5",
  "quote",
  "syn 2.0.48",
 ]
@@ -2057,7 +2102,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
- "darling",
+ "darling 0.20.5",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -4413,6 +4458,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "test-case",
+ "testcontainers",
+ "testcontainers-modules",
  "tokio",
 ]
 
@@ -5408,6 +5455,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5510,6 +5579,8 @@ dependencies = [
  "telemetry-batteries",
  "tempfile",
  "test-case",
+ "testcontainers",
+ "testcontainers-modules",
  "thiserror",
  "tokio",
  "toml 0.8.10",
@@ -6100,6 +6171,32 @@ dependencies = [
  "quote",
  "syn 2.0.48",
  "test-case-core",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d2931d7f521af5bae989f716c3fa43a6af9af7ec7a5e21b59ae40878cec00"
+dependencies = [
+ "bollard-stubs",
+ "futures",
+ "hex",
+ "hmac",
+ "log",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8debb5e215d9e89ea93255fffff00bf037ea44075d7a2669a21a8a988d6b52fd"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,8 @@ semaphore = { git = "https://github.com/worldcoin/semaphore-rs", branch = "main"
 ] }
 similar-asserts = "1.5.0"
 test-case = "3.0"
+testcontainers = "0.15.0"
+testcontainers-modules = {  version = "0.3.7", features = ["postgres"] }
 tracing-subscriber = "0.3.11"
 tracing-test = "0.2"
 

--- a/crates/postgres-docker-utils/Cargo.toml
+++ b/crates/postgres-docker-utils/Cargo.toml
@@ -8,3 +8,5 @@ publish = false
 anyhow = "1.0"
 test-case = "3.1.0"
 tokio = { version = "1.0", features = ["full"] }
+testcontainers = "0.15.0"
+testcontainers-modules = {  version = "0.3.7", features = ["postgres"] }

--- a/crates/postgres-docker-utils/src/lib.rs
+++ b/crates/postgres-docker-utils/src/lib.rs
@@ -1,4 +1,5 @@
-use testcontainers::{clients::Cli, Container, RunnableImage};
+use testcontainers::clients::Cli;
+use testcontainers::{Container, RunnableImage};
 use testcontainers_modules::postgres::Postgres;
 
 pub struct DockerContainer<'a> {
@@ -7,21 +8,17 @@ pub struct DockerContainer<'a> {
 
 impl<'a> DockerContainer<'a> {
     fn new(docker: &'a Cli) -> Self {
-        let image = RunnableImage::from(Postgres::default().with_host_auth()).with_tag("16.2-alpine");
+        let image =
+            RunnableImage::from(Postgres::default().with_host_auth()).with_tag("16.2-alpine");
         let container = docker.run(image);
-        DockerContainer {
-            container,
-        }
+        DockerContainer { container }
     }
 
     pub fn address(&self) -> String {
-        return format!(
-            "127.0.0.1:{}", self.container.get_host_port_ipv4(5432),
-        )
+        format!("127.0.0.1:{}", self.container.get_host_port_ipv4(5432))
     }
 }
 
-
-pub async fn setup<'a>(docker: &'a Cli) -> anyhow::Result<DockerContainer<'a>> {
+pub async fn setup(docker: &Cli) -> anyhow::Result<DockerContainer> {
     Ok(DockerContainer::new(docker))
 }

--- a/crates/postgres-docker-utils/src/lib.rs
+++ b/crates/postgres-docker-utils/src/lib.rs
@@ -1,112 +1,27 @@
-use std::net::SocketAddr;
-use std::process::{Command, Stdio};
-use std::time::Duration;
+use testcontainers::{clients::Cli, Container, RunnableImage};
+use testcontainers_modules::postgres::Postgres;
 
-use anyhow::Context;
-
-pub struct DockerContainerGuard {
-    container_id: String,
-    socket_addr:  SocketAddr,
+pub struct DockerContainer<'a> {
+    container: Container<'a, Postgres>,
 }
 
-impl DockerContainerGuard {
-    pub fn socket_addr(&self) -> SocketAddr {
-        self.socket_addr
+impl<'a> DockerContainer<'a> {
+    fn new(docker: &'a Cli) -> Self {
+        let image = RunnableImage::from(Postgres::default().with_host_auth()).with_tag("16.2-alpine");
+        let container = docker.run(image);
+        DockerContainer {
+            container,
+        }
     }
 
     pub fn address(&self) -> String {
-        self.socket_addr.to_string()
+        return format!(
+            "127.0.0.1:{}", self.container.get_host_port_ipv4(5432),
+        )
     }
 }
 
-impl Drop for DockerContainerGuard {
-    fn drop(&mut self) {
-        if let Err(err) = run_cmd(&format!("docker stop {}", &self.container_id)) {
-            eprintln!("Failed to stop docker container: {}", err);
-        }
 
-        // Redundant, but better safe than sorry
-        if let Err(err) = run_cmd(&format!("docker rm {}", &self.container_id)) {
-            eprintln!("Failed to remove docker container: {}", err);
-        }
-    }
-}
-
-/// Starts a postgres docker container that will accept all connections with a
-/// random port assigned by the os or docker. The container will be stopped and
-/// removed when the guard is dropped.
-///
-/// Note that we're using sync code here so we'll block the executor - but this
-/// is fine, because the spawned container will still run in the background.
-pub async fn setup() -> anyhow::Result<DockerContainerGuard> {
-    let container_id =
-        run_cmd_to_output("docker run --rm -d -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432 postgres")
-            .context("Starting the Postgres container")?;
-
-    let exposed_port = run_cmd_to_output(&format!("docker container port {container_id} 5432"))
-        .context("Fetching container exposed port")?;
-    let socket_addr = parse_exposed_port(&exposed_port)?;
-
-    std::thread::sleep(Duration::from_secs_f32(2.0));
-
-    Ok(DockerContainerGuard {
-        container_id,
-        socket_addr,
-    })
-}
-
-fn run_cmd_to_output(cmd_str: &str) -> anyhow::Result<String> {
-    let args: Vec<_> = cmd_str.split(' ').collect();
-    let mut command = Command::new(args[0]);
-
-    for arg in &args[1..] {
-        command.arg(arg);
-    }
-
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::null());
-
-    let Ok(output) = command.output() else {
-        return Ok(String::new());
-    };
-
-    let utf = String::from_utf8(output.stdout)?;
-
-    Ok(utf.trim().to_string())
-}
-
-fn run_cmd(cmd_str: &str) -> anyhow::Result<()> {
-    run_cmd_to_output(cmd_str)?;
-
-    Ok(())
-}
-
-fn parse_exposed_port(s: &str) -> anyhow::Result<SocketAddr> {
-    let parts: Vec<_> = s
-        .split_whitespace()
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-        .collect();
-
-    Ok(parts
-        .iter()
-        .map(|p| p.parse::<SocketAddr>())
-        .next()
-        .context("Missing exposed port, is your docker daemon running?")??)
-}
-
-#[cfg(test)]
-mod tests {
-    use test_case::test_case;
-
-    use super::*;
-
-    #[test_case("0.0.0.0:55837" => 55837 ; "base case")]
-    #[test_case("   0.0.0.0:55837    " => 55837 ; "ignore whitespace")]
-    #[test_case("[::]:12345" => 12345 ; "works with ipv6")]
-    #[test_case("0.0.0.0:12345 \n [::]:12345" => 12345 ; "works with multiple ips")]
-    #[test_case("0.0.0.0:12345 \n [::]:54321" => 12345 ; "yields first of multiple ips")]
-    fn test_parse_exposed_port(s: &str) -> u16 {
-        parse_exposed_port(s).unwrap().port()
-    }
+pub async fn setup<'a>(docker: &'a Cli) -> anyhow::Result<DockerContainer<'a>> {
+    Ok(DockerContainer::new(docker))
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -860,9 +860,10 @@ mod test {
     use anyhow::Context;
     use chrono::{Days, Utc};
     use ethers::types::U256;
-    use postgres_docker_utils::DockerContainerGuard;
+    use postgres_docker_utils::DockerContainer;
     use ruint::Uint;
     use semaphore::Field;
+    use testcontainers::clients::Cli;
 
     use super::Database;
     use crate::config::DatabaseConfig;
@@ -891,21 +892,32 @@ mod test {
         chrono::Duration::milliseconds(x.num_milliseconds().abs())
     }
 
-    // TODO: we should probably consolidate all tests that propagate errors to
-    // TODO: either use anyhow or eyre
-    async fn setup_db() -> anyhow::Result<(Database, DockerContainerGuard)> {
-        let db_container = postgres_docker_utils::setup().await?;
-        let db_socket_addr = db_container.address();
-        let url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
+    struct DBSetuper {
+        docker: Cli,
+    }
 
-        let db = Database::new(&DatabaseConfig {
-            database:        SecretUrl::from_str(&url)?,
-            migrate:         true,
-            max_connections: 1,
-        })
-        .await?;
+    fn get_db_setuper() -> DBSetuper {
+        DBSetuper {
+            docker: Cli::default(),
+        }
+    }
 
-        Ok((db, db_container))
+    impl DBSetuper {
+        // TODO: we should probably consolidate all tests that propagate errors to
+        // TODO: either use anyhow or eyre
+        async fn setup_db<'a>(&'a self) -> anyhow::Result<(Database, DockerContainer<'a>)> {
+            let db_container = postgres_docker_utils::setup(&self.docker).await?;
+            let url = format!("postgres://postgres:postgres@{}/database", db_container.address());
+
+            let db = Database::new(&DatabaseConfig {
+                database: SecretUrl::from_str(&url)?,
+                migrate: true,
+                max_connections: 1,
+            })
+                .await?;
+
+            Ok((db, db_container))
+        }
     }
 
     fn mock_roots(n: usize) -> Vec<Field> {
@@ -944,7 +956,8 @@ mod test {
 
     #[tokio::test]
     async fn insert_identity() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let dec = "1234500000000000000";
         let commit_hash: Hash = U256::from_dec_str(dec)
             .expect("cant convert to u256")
@@ -978,7 +991,8 @@ mod test {
 
     #[tokio::test]
     async fn insert_and_delete_identity() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let zero: Hash = U256::zero().into();
         let zero_root: Hash = U256::from_dec_str("6789")?.into();
@@ -1020,7 +1034,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_prover_configuration() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let mock_prover_configuration_0 = ProverConfig {
             batch_size:  100,
@@ -1062,7 +1077,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_provers() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let mock_provers = mock_provers();
 
         db.insert_provers(mock_provers.clone()).await?;
@@ -1075,7 +1091,8 @@ mod test {
 
     #[tokio::test]
     async fn test_remove_prover() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let mock_provers = mock_provers();
 
         db.insert_provers(mock_provers.clone()).await?;
@@ -1092,7 +1109,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_new_recovery() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let existing_commitment: Uint<256, 4> = Uint::from(1);
         let new_commitment: Uint<256, 4> = Uint::from(2);
@@ -1111,7 +1129,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_new_deletion() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let existing_commitment: Uint<256, 4> = Uint::from(1);
 
         db.insert_new_deletion(0, &existing_commitment).await?;
@@ -1126,7 +1145,8 @@ mod test {
 
     #[tokio::test]
     async fn test_get_eligible_unprocessed_commitments() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let commitment_0: Uint<256, 4> = Uint::from(1);
         let eligibility_timestamp_0 = Utc::now();
 
@@ -1158,7 +1178,8 @@ mod test {
 
     #[tokio::test]
     async fn test_get_unprocessed_commitments() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         // Insert new identity with a valid eligibility timestamp
         let commitment_0: Uint<256, 4> = Uint::from(1);
@@ -1191,7 +1212,8 @@ mod test {
 
     #[tokio::test]
     async fn test_identity_is_queued_for_deletion() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let existing_commitment: Uint<256, 4> = Uint::from(1);
 
         db.insert_new_deletion(0, &existing_commitment).await?;
@@ -1206,7 +1228,8 @@ mod test {
 
     #[tokio::test]
     async fn test_update_eligibility_timestamp() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let dec = "1234500000000000000";
         let commit_hash: Hash = U256::from_dec_str(dec)
             .expect("cant convert to u256")
@@ -1247,7 +1270,8 @@ mod test {
 
     #[tokio::test]
     async fn test_update_insertion_timestamp() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let insertion_timestamp = Utc::now();
 
@@ -1263,7 +1287,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_deletion() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let identities = mock_identities(3);
 
         db.insert_new_deletion(0, &identities[0]).await?;
@@ -1279,7 +1304,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_recovery() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let old_identities = mock_identities(3);
         let new_identities = mock_identities(3);
@@ -1296,7 +1322,8 @@ mod test {
 
     #[tokio::test]
     async fn test_delete_recoveries() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let old_identities = mock_identities(3);
         let new_identities = mock_identities(3);
@@ -1318,7 +1345,8 @@ mod test {
 
     #[tokio::test]
     async fn get_last_leaf_index() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let identities = mock_identities(1);
         let roots = mock_roots(1);
@@ -1338,7 +1366,8 @@ mod test {
 
     #[tokio::test]
     async fn mark_all_as_pending_marks_all() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1367,7 +1396,8 @@ mod test {
 
     #[tokio::test]
     async fn mark_root_as_processed_marks_previous_roots() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1409,7 +1439,8 @@ mod test {
 
     #[tokio::test]
     async fn mark_root_as_mined_marks_previous_roots() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1451,7 +1482,8 @@ mod test {
 
     #[tokio::test]
     async fn mark_root_as_mined_interaction_with_mark_root_as_processed() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let num_identities = 6;
 
@@ -1494,7 +1526,8 @@ mod test {
 
     #[tokio::test]
     async fn mark_root_as_processed_marks_next_roots() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1537,7 +1570,8 @@ mod test {
 
     #[tokio::test]
     async fn root_history_timing() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1594,7 +1628,8 @@ mod test {
 
     #[tokio::test]
     async fn get_commitments_by_status() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let identities = mock_identities(5);
 
@@ -1632,7 +1667,8 @@ mod test {
 
     #[tokio::test]
     async fn get_commitments_by_status_results_are_in_id_order() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let identities = mock_identities(5);
 
@@ -1686,7 +1722,8 @@ mod test {
 
     #[tokio::test]
     async fn test_root_invalidation() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1762,7 +1799,8 @@ mod test {
 
     #[tokio::test]
     async fn check_identity_existence() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let identities = mock_identities(2);
         let roots = mock_roots(1);
@@ -1790,7 +1828,8 @@ mod test {
 
     #[tokio::test]
     async fn test_remove_deletions() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         let identities = mock_identities(4);
 
@@ -1821,7 +1860,8 @@ mod test {
 
     #[tokio::test]
     async fn test_latest_deletion_root() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
 
         // Update with initial timestamp
         let initial_timestamp = chrono::Utc::now();
@@ -1848,7 +1888,8 @@ mod test {
 
     #[tokio::test]
     async fn test_history_unprocessed_identities() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let identities = mock_identities(2);
 
         let now = Utc::now();
@@ -1886,7 +1927,8 @@ mod test {
 
     #[tokio::test]
     async fn test_history_unprocessed_deletion_identities() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let identities = mock_identities(2);
         let roots = mock_roots(2);
 
@@ -1918,7 +1960,8 @@ mod test {
 
     #[tokio::test]
     async fn test_history_processed_deletion_identities() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let identities = mock_identities(2);
         let roots = mock_roots(2);
 
@@ -1948,7 +1991,8 @@ mod test {
 
     #[tokio::test]
     async fn test_history_processed_identity() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let identities = mock_identities(2);
         let roots = mock_roots(2);
 
@@ -1983,7 +2027,8 @@ mod test {
 
     #[tokio::test]
     async fn can_insert_same_root_multiple_times() -> anyhow::Result<()> {
-        let (db, _db_container) = setup_db().await?;
+        let db_setuper = get_db_setuper();
+        let (db, _db_container) = db_setuper.setup_db().await?;
         let identities = mock_identities(2);
         let roots = mock_roots(2);
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -22,9 +22,9 @@ use crate::config::DatabaseConfig;
 use crate::identity_tree::{
     Hash, ProcessedStatus, RootItem, TreeItem, TreeUpdate, UnprocessedStatus,
 };
+use crate::prover::{ProverConfig, ProverType};
 
 pub mod types;
-use crate::prover::{ProverConfig, ProverType};
 
 // Statically link in migration files
 static MIGRATOR: Migrator = sqlx::migrate!("schemas/database");
@@ -892,32 +892,23 @@ mod test {
         chrono::Duration::milliseconds(x.num_milliseconds().abs())
     }
 
-    struct DBSetuper {
-        docker: Cli,
-    }
+    // TODO: we should probably consolidate all tests that propagate errors to
+    // TODO: either use anyhow or eyre
+    async fn setup_db<'a>(docker: &'a Cli) -> anyhow::Result<(Database, DockerContainer)> {
+        let db_container = postgres_docker_utils::setup(docker).await?;
+        let url = format!(
+            "postgres://postgres:postgres@{}/database",
+            db_container.address()
+        );
 
-    fn get_db_setuper() -> DBSetuper {
-        DBSetuper {
-            docker: Cli::default(),
-        }
-    }
+        let db = Database::new(&DatabaseConfig {
+            database:        SecretUrl::from_str(&url)?,
+            migrate:         true,
+            max_connections: 1,
+        })
+        .await?;
 
-    impl DBSetuper {
-        // TODO: we should probably consolidate all tests that propagate errors to
-        // TODO: either use anyhow or eyre
-        async fn setup_db<'a>(&'a self) -> anyhow::Result<(Database, DockerContainer<'a>)> {
-            let db_container = postgres_docker_utils::setup(&self.docker).await?;
-            let url = format!("postgres://postgres:postgres@{}/database", db_container.address());
-
-            let db = Database::new(&DatabaseConfig {
-                database: SecretUrl::from_str(&url)?,
-                migrate: true,
-                max_connections: 1,
-            })
-                .await?;
-
-            Ok((db, db_container))
-        }
+        Ok((db, db_container))
     }
 
     fn mock_roots(n: usize) -> Vec<Field> {
@@ -956,8 +947,8 @@ mod test {
 
     #[tokio::test]
     async fn insert_identity() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let dec = "1234500000000000000";
         let commit_hash: Hash = U256::from_dec_str(dec)
             .expect("cant convert to u256")
@@ -991,8 +982,8 @@ mod test {
 
     #[tokio::test]
     async fn insert_and_delete_identity() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let zero: Hash = U256::zero().into();
         let zero_root: Hash = U256::from_dec_str("6789")?.into();
@@ -1034,8 +1025,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_prover_configuration() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let mock_prover_configuration_0 = ProverConfig {
             batch_size:  100,
@@ -1077,8 +1068,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_provers() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let mock_provers = mock_provers();
 
         db.insert_provers(mock_provers.clone()).await?;
@@ -1091,8 +1082,8 @@ mod test {
 
     #[tokio::test]
     async fn test_remove_prover() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let mock_provers = mock_provers();
 
         db.insert_provers(mock_provers.clone()).await?;
@@ -1109,8 +1100,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_new_recovery() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let existing_commitment: Uint<256, 4> = Uint::from(1);
         let new_commitment: Uint<256, 4> = Uint::from(2);
@@ -1129,8 +1120,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_new_deletion() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let existing_commitment: Uint<256, 4> = Uint::from(1);
 
         db.insert_new_deletion(0, &existing_commitment).await?;
@@ -1145,8 +1136,8 @@ mod test {
 
     #[tokio::test]
     async fn test_get_eligible_unprocessed_commitments() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let commitment_0: Uint<256, 4> = Uint::from(1);
         let eligibility_timestamp_0 = Utc::now();
 
@@ -1178,8 +1169,8 @@ mod test {
 
     #[tokio::test]
     async fn test_get_unprocessed_commitments() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         // Insert new identity with a valid eligibility timestamp
         let commitment_0: Uint<256, 4> = Uint::from(1);
@@ -1212,8 +1203,8 @@ mod test {
 
     #[tokio::test]
     async fn test_identity_is_queued_for_deletion() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let existing_commitment: Uint<256, 4> = Uint::from(1);
 
         db.insert_new_deletion(0, &existing_commitment).await?;
@@ -1228,8 +1219,8 @@ mod test {
 
     #[tokio::test]
     async fn test_update_eligibility_timestamp() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let dec = "1234500000000000000";
         let commit_hash: Hash = U256::from_dec_str(dec)
             .expect("cant convert to u256")
@@ -1270,8 +1261,8 @@ mod test {
 
     #[tokio::test]
     async fn test_update_insertion_timestamp() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let insertion_timestamp = Utc::now();
 
@@ -1287,8 +1278,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_deletion() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let identities = mock_identities(3);
 
         db.insert_new_deletion(0, &identities[0]).await?;
@@ -1304,8 +1295,8 @@ mod test {
 
     #[tokio::test]
     async fn test_insert_recovery() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let old_identities = mock_identities(3);
         let new_identities = mock_identities(3);
@@ -1322,8 +1313,8 @@ mod test {
 
     #[tokio::test]
     async fn test_delete_recoveries() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let old_identities = mock_identities(3);
         let new_identities = mock_identities(3);
@@ -1345,8 +1336,8 @@ mod test {
 
     #[tokio::test]
     async fn get_last_leaf_index() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let identities = mock_identities(1);
         let roots = mock_roots(1);
@@ -1366,8 +1357,8 @@ mod test {
 
     #[tokio::test]
     async fn mark_all_as_pending_marks_all() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1396,8 +1387,8 @@ mod test {
 
     #[tokio::test]
     async fn mark_root_as_processed_marks_previous_roots() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1439,8 +1430,8 @@ mod test {
 
     #[tokio::test]
     async fn mark_root_as_mined_marks_previous_roots() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1482,8 +1473,8 @@ mod test {
 
     #[tokio::test]
     async fn mark_root_as_mined_interaction_with_mark_root_as_processed() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let num_identities = 6;
 
@@ -1526,8 +1517,8 @@ mod test {
 
     #[tokio::test]
     async fn mark_root_as_processed_marks_next_roots() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1570,8 +1561,8 @@ mod test {
 
     #[tokio::test]
     async fn root_history_timing() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1628,8 +1619,8 @@ mod test {
 
     #[tokio::test]
     async fn get_commitments_by_status() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let identities = mock_identities(5);
 
@@ -1667,8 +1658,8 @@ mod test {
 
     #[tokio::test]
     async fn get_commitments_by_status_results_are_in_id_order() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let identities = mock_identities(5);
 
@@ -1722,8 +1713,8 @@ mod test {
 
     #[tokio::test]
     async fn test_root_invalidation() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let identities = mock_identities(5);
         let roots = mock_roots(5);
@@ -1799,8 +1790,8 @@ mod test {
 
     #[tokio::test]
     async fn check_identity_existence() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let identities = mock_identities(2);
         let roots = mock_roots(1);
@@ -1828,8 +1819,8 @@ mod test {
 
     #[tokio::test]
     async fn test_remove_deletions() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         let identities = mock_identities(4);
 
@@ -1860,8 +1851,8 @@ mod test {
 
     #[tokio::test]
     async fn test_latest_deletion_root() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
 
         // Update with initial timestamp
         let initial_timestamp = chrono::Utc::now();
@@ -1888,8 +1879,8 @@ mod test {
 
     #[tokio::test]
     async fn test_history_unprocessed_identities() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let identities = mock_identities(2);
 
         let now = Utc::now();
@@ -1927,8 +1918,8 @@ mod test {
 
     #[tokio::test]
     async fn test_history_unprocessed_deletion_identities() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let identities = mock_identities(2);
         let roots = mock_roots(2);
 
@@ -1960,8 +1951,8 @@ mod test {
 
     #[tokio::test]
     async fn test_history_processed_deletion_identities() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let identities = mock_identities(2);
         let roots = mock_roots(2);
 
@@ -1991,8 +1982,8 @@ mod test {
 
     #[tokio::test]
     async fn test_history_processed_identity() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let identities = mock_identities(2);
         let roots = mock_roots(2);
 
@@ -2027,8 +2018,8 @@ mod test {
 
     #[tokio::test]
     async fn can_insert_same_root_multiple_times() -> anyhow::Result<()> {
-        let db_setuper = get_db_setuper();
-        let (db, _db_container) = db_setuper.setup_db().await?;
+        let docker = Cli::default();
+        let (db, _db_container) = setup_db(&docker).await?;
         let identities = mock_identities(2);
         let roots = mock_roots(2);
 

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -81,6 +81,10 @@ mod tests {
 
     use super::*;
 
+    // This test is ignored due to global variable being used to indicate if system is shutting
+    // down. Because tests are being run in parallel it is causing unpredictable behaviour and
+    // random test failures.
+    #[ignore]
     #[tokio::test]
     async fn shutdown_signal() {
         let start = tokio::time::Instant::now();

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -74,31 +74,3 @@ async fn signal_shutdown() -> Result<()> {
     info!("Ctrl-C received, shutting down");
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    use tokio::time::{sleep, Duration};
-
-    use super::*;
-
-    // This test is ignored due to global variable being used to indicate if system is shutting
-    // down. Because tests are being run in parallel it is causing unpredictable behaviour and
-    // random test failures.
-    #[ignore]
-    #[tokio::test]
-    async fn shutdown_signal() {
-        let start = tokio::time::Instant::now();
-
-        tokio::spawn(async {
-            sleep(Duration::from_millis(100)).await;
-            shutdown();
-        });
-
-        await_shutdown().await;
-
-        let elapsed = start.elapsed();
-
-        assert!(elapsed > Duration::from_millis(100));
-        assert!(elapsed < Duration::from_millis(200));
-    }
-}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -253,10 +253,6 @@ version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.base64]]
-version = "0.13.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.base64]]
 version = "0.21.7"
 criteria = "safe-to-deploy"
 
@@ -280,16 +276,16 @@ criteria = "safe-to-deploy"
 version = "1.3.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.bitflags]]
-version = "2.4.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.bitvec]]
 version = "1.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.blake2]]
 version = "0.9.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.bollard-stubs]]
+version = "1.42.0-rc.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.bs58]]
@@ -416,10 +412,6 @@ criteria = "safe-to-deploy"
 version = "0.1.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.core-foundation]]
-version = "0.9.4"
-criteria = "safe-to-deploy"
-
 [[exemptions.cpufeatures]]
 version = "0.2.12"
 criteria = "safe-to-deploy"
@@ -485,11 +477,23 @@ version = "0.9.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling]]
+version = "0.13.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling]]
 version = "0.20.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling_core]]
+version = "0.13.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling_core]]
 version = "0.20.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling_macro]]
+version = "0.13.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling_macro]]
@@ -522,10 +526,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.dirs]]
 version = "5.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.dirs-next]]
-version = "2.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.dirs-sys]]
@@ -908,10 +908,6 @@ criteria = "safe-to-deploy"
 version = "0.25.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.linked-hash-map]]
-version = "0.5.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.linux-raw-sys]]
 version = "0.4.13"
 criteria = "safe-to-deploy"
@@ -930,10 +926,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.mach]]
 version = "0.3.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.mach2]]
-version = "0.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.maplit]]
@@ -998,10 +990,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.nix]]
 version = "0.15.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.nom]]
-version = "7.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.num]]
@@ -1248,10 +1236,6 @@ criteria = "safe-to-deploy"
 version = "1.0.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.proc-macro2]]
-version = "1.0.78"
-criteria = "safe-to-deploy"
-
 [[exemptions.prometheus]]
 version = "0.13.3"
 criteria = "safe-to-deploy"
@@ -1484,6 +1468,14 @@ criteria = "safe-to-deploy"
 version = "0.7.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.serde_with]]
+version = "1.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_with_macros]]
+version = "1.5.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.sha1]]
 version = "0.10.6"
 criteria = "safe-to-deploy"
@@ -1580,28 +1572,12 @@ criteria = "safe-to-deploy"
 version = "1.2.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.static_assertions]]
-version = "1.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.string_cache]]
 version = "0.8.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.stringprep]]
 version = "0.1.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.strsim]]
-version = "0.10.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.strum]]
-version = "0.25.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.strum_macros]]
-version = "0.25.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.svm-rs]]
@@ -1646,6 +1622,14 @@ criteria = "safe-to-deploy"
 
 [[exemptions.test-case-macros]]
 version = "3.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.testcontainers]]
+version = "0.15.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.testcontainers-modules]]
+version = "0.3.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.textwrap]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -85,6 +85,13 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.core-foundation]]
+version = "0.9.3"
+when = "2022-02-07"
+user-id = 5946
+user-login = "jrmuizel"
+user-name = "Jeff Muizelaar"
+
 [[publisher.core-foundation-sys]]
 version = "0.8.4"
 when = "2023-04-03"
@@ -995,6 +1002,12 @@ This is a minor update which has some testing affordances as well as some
 updated math algorithms.
 """
 
+[[audits.bytecodealliance.audits.mach2]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.1 -> 0.4.2"
+notes = "It does unsafe FFI bindings, as expected. I didn't check the FFI bindings against the C headers."
+
 [[audits.bytecodealliance.audits.matchers]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -1080,6 +1093,12 @@ notes = "I always really enjoy reading eliza's code, she left perfect comments a
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "1.4.1"
+
+[[audits.bytecodealliance.audits.static_assertions]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = "No dependencies and completely a compile-time crate as advertised. Uses `unsafe` in one module as a compile-time check only: `mem::transmute` and `ptr::write` are wrapped in an impossible-to-run closure."
 
 [[audits.bytecodealliance.audits.thread_local]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -1245,6 +1264,36 @@ delta = "0.3.4 -> 0.3.5"
 notes = "Reviewed on https://fxrev.dev/906795"
 aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.base64]]
+who = "Adam Langley <agl@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.13.1"
+notes = "Skimmed the uses of `std` to ensure that nothing untoward is happening. Code uses `forbid(unsafe_code)` and, indeed, there are no uses of `unsafe`"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.bitflags]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "2.4.2"
+notes = """
+Audit notes:
+
+* I've checked for any discussion in Google-internal cl/546819168 (where audit
+  of version 2.3.3 happened)
+* `src/lib.rs` contains `#![cfg_attr(not(test), forbid(unsafe_code))]`
+* There are 2 cases of `unsafe` in `src/external.rs` but they seem to be
+  correct in a straightforward way - they just propagate the marker trait's
+  impl (e.g. `impl bytemuck::Pod`) from the inner to the outer type
+* Additional discussion and/or notes may be found in https://crrev.com/c/5238056
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.dirs-next]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.google.audits.fastrand]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
@@ -1267,6 +1316,15 @@ criteria = "safe-to-deploy"
 version = "1.0.3"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.nom]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "7.1.3"
+notes = """
+Reviewed in https://chromium-review.googlesource.com/c/chromium/src/+/5046153
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.openssl-macros]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
@@ -1285,6 +1343,51 @@ who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 version = "1.0.4"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.78"
+notes = """
+Grepped for \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits
+(except for a benign \"fs\" hit in a doc comment)
+
+Notes from the `unsafe` review can be found in https://crrev.com/c/5385745.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.strsim]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "0.10.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.strum]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "0.25.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.strum_macros]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "0.25.3"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.take_mut]]
 who = "David Koloski <dkoloski@google.com>"
@@ -1450,6 +1553,16 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.7.1"
 
+[[audits.mozilla.wildcard-audits.core-foundation]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 5946 # Jeff Muizelaar (jrmuizel)
+start = "2019-03-29"
+end = "2023-05-04"
+renew = false
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.wildcard-audits.core-foundation-sys]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -1559,6 +1672,13 @@ who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.78 -> 1.0.83"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.core-foundation]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.3 -> 0.9.4"
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.crossbeam-channel]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
@@ -1726,6 +1846,20 @@ criteria = "safe-to-deploy"
 delta = "0.26.0 -> 0.27.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.linked-hash-map]]
+who = "Aria Beingessner <a.beingessner@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.4"
+notes = "I own this crate (I am contain-rs) and 0.5.4 passes miri. This code is very old and used by lots of people, so I'm pretty confident in it, even though it's in maintenance-mode and missing some nice-to-have APIs."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.linked-hash-map]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.4 -> 0.5.6"
+notes = "New unsafe code has debug assertions and meets invariants. All other changes are formatting-related."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.log]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -1745,6 +1879,12 @@ criteria = "safe-to-deploy"
 delta = "0.4.18 -> 0.4.20"
 notes = "Only cfg attribute and internal macro changes and module refactorings"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.mach2]]
+who = "Gabriele Svelto <gsvelto@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.4.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.memoffset]]
 who = "Gabriele Svelto <gsvelto@mozilla.com>"
@@ -1782,12 +1922,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Gabriele Svelto <gsvelto@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "0.26.2 -> 0.27.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.nom]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "7.1.1 -> 7.1.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-bigint]]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -28,7 +28,7 @@ pub mod prelude {
     pub use hyper::client::HttpConnector;
     pub use hyper::{Body, Client, Request};
     pub use once_cell::sync::Lazy;
-    pub use postgres_docker_utils::DockerContainerGuard;
+    pub use postgres_docker_utils::DockerContainer;
     pub use semaphore::identity::Identity;
     pub use semaphore::merkle_tree::{self, Branch};
     pub use semaphore::poseidon_tree::{PoseidonHash, PoseidonTree};
@@ -74,6 +74,7 @@ use std::sync::Arc;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use hyper::StatusCode;
+use testcontainers::clients::Cli;
 use signup_sequencer::identity_tree::{Status, TreeState, TreeVersionReadOps};
 use signup_sequencer::task_monitor::TaskMonitor;
 use tracing::trace;
@@ -675,14 +676,15 @@ struct CompiledContract {
     bytecode: Bytecode,
 }
 
-pub async fn spawn_deps(
+pub async fn spawn_deps<'a, 'b, 'c>(
     initial_root: U256,
-    insertion_batch_sizes: &[usize],
-    deletion_batch_sizes: &[usize],
+    insertion_batch_sizes: &'b [usize],
+    deletion_batch_sizes: &'c [usize],
     tree_depth: u8,
+    docker: &'a Cli,
 ) -> anyhow::Result<(
     MockChain,
-    DockerContainerGuard,
+    DockerContainer<'a>,
     HashMap<usize, ProverService>,
     HashMap<usize, ProverService>,
     micro_oz::ServerHandle,
@@ -694,7 +696,7 @@ pub async fn spawn_deps(
         tree_depth,
     );
 
-    let db_container = spawn_db();
+    let db_container = spawn_db(docker);
 
     let insertion_prover_futures = FuturesUnordered::new();
     for batch_size in insertion_batch_sizes {
@@ -744,8 +746,8 @@ pub async fn spawn_deps(
     ))
 }
 
-async fn spawn_db() -> anyhow::Result<DockerContainerGuard> {
-    let db_container = postgres_docker_utils::setup().await.unwrap();
+async fn spawn_db<'a>(docker: &'a Cli) -> anyhow::Result<DockerContainer<'a>> {
+    let db_container = postgres_docker_utils::setup(docker).await.unwrap();
 
     Ok(db_container)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -45,6 +45,7 @@ pub mod prelude {
     pub use signup_sequencer::prover::ProverType;
     pub use signup_sequencer::server;
     pub use signup_sequencer::shutdown::{reset_shutdown, shutdown};
+    pub use testcontainers::clients::Cli;
     pub use tokio::spawn;
     pub use tokio::task::JoinHandle;
     pub use tracing::{error, info, instrument};
@@ -74,9 +75,9 @@ use std::sync::Arc;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use hyper::StatusCode;
-use testcontainers::clients::Cli;
 use signup_sequencer::identity_tree::{Status, TreeState, TreeVersionReadOps};
 use signup_sequencer::task_monitor::TaskMonitor;
+use testcontainers::clients::Cli;
 use tracing::trace;
 
 use self::chain_mock::{spawn_mock_chain, MockChain, SpecialisedContract};

--- a/tests/delete_identities.rs
+++ b/tests/delete_identities.rs
@@ -2,7 +2,6 @@
 
 mod common;
 
-use testcontainers::clients::Cli;
 use common::prelude::*;
 
 use crate::common::test_delete_identity;

--- a/tests/delete_identities.rs
+++ b/tests/delete_identities.rs
@@ -2,6 +2,7 @@
 
 mod common;
 
+use testcontainers::clients::Cli;
 use common::prelude::*;
 
 use crate::common::test_delete_identity;
@@ -20,12 +21,14 @@ async fn delete_identities() -> anyhow::Result<()> {
     let mut ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
     let initial_root: U256 = ref_tree.root().into();
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, deletion_prover_map, micro_oz) =
         spawn_deps(
             initial_root,
             &[insertion_batch_size],
             &[deletion_batch_size],
             DEFAULT_TREE_DEPTH as u8,
+            &docker,
         )
         .await?;
 

--- a/tests/delete_padded_identity.rs
+++ b/tests/delete_padded_identity.rs
@@ -2,7 +2,6 @@
 
 mod common;
 
-use testcontainers::clients::Cli;
 use common::prelude::*;
 
 use crate::common::test_delete_identity;

--- a/tests/delete_padded_identity.rs
+++ b/tests/delete_padded_identity.rs
@@ -2,6 +2,7 @@
 
 mod common;
 
+use testcontainers::clients::Cli;
 use common::prelude::*;
 
 use crate::common::test_delete_identity;
@@ -20,12 +21,14 @@ async fn delete_padded_identity() -> anyhow::Result<()> {
     let mut ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
     let initial_root: U256 = ref_tree.root().into();
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, deletion_prover_map, micro_oz) =
         spawn_deps(
             initial_root,
             &[insertion_batch_size],
             &[deletion_batch_size],
             DEFAULT_TREE_DEPTH as u8,
+            &docker,
         )
         .await?;
 

--- a/tests/dynamic_batch_sizes.rs
+++ b/tests/dynamic_batch_sizes.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use common::prelude::*;
 use hyper::Uri;
+use testcontainers::clients::Cli;
 
 use crate::common::{test_add_batch_size, test_remove_batch_size};
 
@@ -21,11 +22,13 @@ async fn dynamic_batch_sizes() -> anyhow::Result<()> {
     let mut ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
     let initial_root: U256 = ref_tree.root().into();
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
         initial_root,
         &[first_batch_size, second_batch_size],
         &[],
         DEFAULT_TREE_DEPTH as u8,
+        &docker,
     )
     .await?;
 

--- a/tests/dynamic_batch_sizes.rs
+++ b/tests/dynamic_batch_sizes.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 
 use common::prelude::*;
 use hyper::Uri;
-use testcontainers::clients::Cli;
 
 use crate::common::{test_add_batch_size, test_remove_batch_size};
 

--- a/tests/identity_history.rs
+++ b/tests/identity_history.rs
@@ -2,7 +2,6 @@ mod common;
 
 use common::prelude::*;
 use hyper::StatusCode;
-use testcontainers::clients::Cli;
 use signup_sequencer::server::data::{
     IdentityHistoryEntryStatus, IdentityHistoryRequest, IdentityHistoryResponse,
 };

--- a/tests/identity_history.rs
+++ b/tests/identity_history.rs
@@ -2,6 +2,7 @@ mod common;
 
 use common::prelude::*;
 use hyper::StatusCode;
+use testcontainers::clients::Cli;
 use signup_sequencer::server::data::{
     IdentityHistoryEntryStatus, IdentityHistoryRequest, IdentityHistoryResponse,
 };
@@ -23,12 +24,14 @@ async fn identity_history() -> anyhow::Result<()> {
     let mut ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
     let initial_root: U256 = ref_tree.root().into();
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, deletion_prover_map, micro_oz) =
         spawn_deps(
             initial_root,
             &[insertion_batch_size],
             &[deletion_batch_size],
             DEFAULT_TREE_DEPTH as u8,
+            &docker,
         )
         .await?;
 

--- a/tests/insert_identity_and_proofs.rs
+++ b/tests/insert_identity_and_proofs.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use common::prelude::*;
-use testcontainers::clients::Cli;
 
 const IDLE_TIME: u64 = 7;
 
@@ -17,8 +16,14 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
     let initial_root: U256 = ref_tree.root().into();
 
     let docker = Cli::default();
-    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
+    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
+        initial_root,
+        &[batch_size],
+        &[],
+        DEFAULT_TREE_DEPTH as u8,
+        &docker,
+    )
+    .await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/insert_identity_and_proofs.rs
+++ b/tests/insert_identity_and_proofs.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::prelude::*;
+use testcontainers::clients::Cli;
 
 const IDLE_TIME: u64 = 7;
 
@@ -15,8 +16,9 @@ async fn insert_identity_and_proofs() -> anyhow::Result<()> {
     let mut ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
     let initial_root: U256 = ref_tree.root().into();
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8).await?;
+        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/malformed_payload.rs
+++ b/tests/malformed_payload.rs
@@ -2,7 +2,6 @@ mod common;
 
 use common::prelude::*;
 use hyper::StatusCode;
-use testcontainers::clients::Cli;
 
 /// Tests that the app rejects payloads which are too large or are not valid
 /// UTF-8 strings
@@ -17,8 +16,14 @@ async fn malformed_payload() -> anyhow::Result<()> {
     let batch_size: usize = 3;
 
     let docker = Cli::default();
-    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
+    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
+        initial_root,
+        &[batch_size],
+        &[],
+        DEFAULT_TREE_DEPTH as u8,
+        &docker,
+    )
+    .await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/malformed_payload.rs
+++ b/tests/malformed_payload.rs
@@ -2,6 +2,7 @@ mod common;
 
 use common::prelude::*;
 use hyper::StatusCode;
+use testcontainers::clients::Cli;
 
 /// Tests that the app rejects payloads which are too large or are not valid
 /// UTF-8 strings
@@ -15,8 +16,9 @@ async fn malformed_payload() -> anyhow::Result<()> {
 
     let batch_size: usize = 3;
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8).await?;
+        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/more_identities_than_dense_prefix.rs
+++ b/tests/more_identities_than_dense_prefix.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::prelude::*;
+use testcontainers::clients::Cli;
 
 const IDLE_TIME: u64 = 12;
 
@@ -27,8 +28,9 @@ async fn more_identities_than_dense_prefix() -> anyhow::Result<()> {
     let mut ref_tree = PoseidonTree::new(tree_depth + 1, ruint::Uint::ZERO);
     let initial_root: U256 = ref_tree.root().into();
 
+    let docker = Cli::default();
     let (mock_chain, db_container, prover_map, _deletion_prover_map, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], tree_depth as u8).await?;
+        spawn_deps(initial_root, &[batch_size], &[], tree_depth as u8, &docker).await?;
 
     let prover_mock = &prover_map[&batch_size];
 

--- a/tests/more_identities_than_dense_prefix.rs
+++ b/tests/more_identities_than_dense_prefix.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use common::prelude::*;
-use testcontainers::clients::Cli;
 
 const IDLE_TIME: u64 = 12;
 

--- a/tests/multi_prover.rs
+++ b/tests/multi_prover.rs
@@ -1,6 +1,5 @@
 mod common;
 
-use testcontainers::clients::Cli;
 use common::prelude::*;
 
 /// Tests that the app can keep running even if the prover returns 500s

--- a/tests/multi_prover.rs
+++ b/tests/multi_prover.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use testcontainers::clients::Cli;
 use common::prelude::*;
 
 /// Tests that the app can keep running even if the prover returns 500s
@@ -17,11 +18,13 @@ async fn multi_prover() -> anyhow::Result<()> {
     let batch_size_3: usize = 3;
     let batch_size_10: usize = 10;
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
         initial_root,
         &[batch_size_3, batch_size_10],
         &[],
         DEFAULT_TREE_DEPTH as u8,
+        &docker,
     )
     .await?;
 

--- a/tests/recover_identities.rs
+++ b/tests/recover_identities.rs
@@ -2,6 +2,7 @@
 
 mod common;
 
+use testcontainers::clients::Cli;
 use common::prelude::*;
 use signup_sequencer::identity_tree::{ProcessedStatus, UnprocessedStatus};
 
@@ -21,12 +22,14 @@ async fn recover_identities() -> anyhow::Result<()> {
     let mut ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
     let initial_root: U256 = ref_tree.root().into();
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, deletion_prover_map, micro_oz) =
         spawn_deps(
             initial_root,
             &[insertion_batch_size],
             &[deletion_batch_size],
             DEFAULT_TREE_DEPTH as u8,
+            &docker,
         )
         .await?;
 

--- a/tests/recover_identities.rs
+++ b/tests/recover_identities.rs
@@ -2,7 +2,6 @@
 
 mod common;
 
-use testcontainers::clients::Cli;
 use common::prelude::*;
 use signup_sequencer::identity_tree::{ProcessedStatus, UnprocessedStatus};
 

--- a/tests/tree_restore_empty.rs
+++ b/tests/tree_restore_empty.rs
@@ -1,6 +1,6 @@
-use common::prelude::*;
-
 mod common;
+
+use common::prelude::*;
 
 #[tokio::test]
 async fn tree_restore_empty() -> anyhow::Result<()> {
@@ -13,8 +13,15 @@ async fn tree_restore_empty() -> anyhow::Result<()> {
     let ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
     let initial_root: U256 = ref_tree.root().into();
 
-    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8).await?;
+    let docker = Cli::default();
+    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
+        initial_root,
+        &[batch_size],
+        &[],
+        DEFAULT_TREE_DEPTH as u8,
+        &docker,
+    )
+    .await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/tree_restore_multiple_commitments.rs
+++ b/tests/tree_restore_multiple_commitments.rs
@@ -1,6 +1,6 @@
-use common::prelude::*;
-
 mod common;
+
+use common::prelude::*;
 
 const IDLE_TIME: u64 = 7;
 
@@ -15,8 +15,15 @@ async fn tree_restore_multiple_comittments() -> anyhow::Result<()> {
     let mut ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
     let initial_root: U256 = ref_tree.root().into();
 
-    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8).await?;
+    let docker = Cli::default();
+    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
+        initial_root,
+        &[batch_size],
+        &[],
+        DEFAULT_TREE_DEPTH as u8,
+        &docker,
+    )
+    .await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/tree_restore_one_commitment.rs
+++ b/tests/tree_restore_one_commitment.rs
@@ -1,6 +1,6 @@
-use common::prelude::*;
-
 mod common;
+
+use common::prelude::*;
 
 const IDLE_TIME: u64 = 7;
 
@@ -15,8 +15,15 @@ async fn tree_restore_one_comittment() -> anyhow::Result<()> {
     let mut ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
     let initial_root: U256 = ref_tree.root().into();
 
-    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8).await?;
+    let docker = Cli::default();
+    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
+        initial_root,
+        &[batch_size],
+        &[],
+        DEFAULT_TREE_DEPTH as u8,
+        &docker,
+    )
+    .await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/unavailable_prover.rs
+++ b/tests/unavailable_prover.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use testcontainers::clients::Cli;
 use common::prelude::*;
 
 /// Tests that the app can keep running even if the prover returns 500s
@@ -14,8 +15,9 @@ async fn unavailable_prover() -> anyhow::Result<()> {
 
     let batch_size: usize = 3;
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8).await?;
+        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/unavailable_prover.rs
+++ b/tests/unavailable_prover.rs
@@ -1,6 +1,5 @@
 mod common;
 
-use testcontainers::clients::Cli;
 use common::prelude::*;
 
 /// Tests that the app can keep running even if the prover returns 500s
@@ -16,8 +15,14 @@ async fn unavailable_prover() -> anyhow::Result<()> {
     let batch_size: usize = 3;
 
     let docker = Cli::default();
-    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
+    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
+        initial_root,
+        &[batch_size],
+        &[],
+        DEFAULT_TREE_DEPTH as u8,
+        &docker,
+    )
+    .await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/unreduced_identity.rs
+++ b/tests/unreduced_identity.rs
@@ -1,6 +1,5 @@
 mod common;
 use common::prelude::*;
-use testcontainers::clients::Cli;
 
 #[tokio::test]
 async fn test_unreduced_identity() -> anyhow::Result<()> {
@@ -11,8 +10,14 @@ async fn test_unreduced_identity() -> anyhow::Result<()> {
     let batch_size: usize = 3;
 
     let docker = Cli::default();
-    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
+    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
+        initial_root,
+        &[batch_size],
+        &[],
+        DEFAULT_TREE_DEPTH as u8,
+        &docker,
+    )
+    .await?;
     let prover_mock = &insertion_prover_map[&batch_size];
     prover_mock.set_availability(false).await;
 

--- a/tests/unreduced_identity.rs
+++ b/tests/unreduced_identity.rs
@@ -1,5 +1,6 @@
 mod common;
 use common::prelude::*;
+use testcontainers::clients::Cli;
 
 #[tokio::test]
 async fn test_unreduced_identity() -> anyhow::Result<()> {
@@ -9,8 +10,9 @@ async fn test_unreduced_identity() -> anyhow::Result<()> {
     let initial_root: U256 = ref_tree.root().into();
     let batch_size: usize = 3;
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8).await?;
+        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
     let prover_mock = &insertion_prover_map[&batch_size];
     prover_mock.set_availability(false).await;
 

--- a/tests/validate_proof_with_age.rs
+++ b/tests/validate_proof_with_age.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use std::time::Instant;
-use testcontainers::clients::Cli;
 
 use common::prelude::*;
 
@@ -23,7 +22,14 @@ async fn validate_proof_with_age() -> anyhow::Result<()> {
 
     let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, _deletion_prover_map, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
+        spawn_deps(
+            initial_root,
+            &[batch_size],
+            &[],
+            DEFAULT_TREE_DEPTH as u8,
+            &docker,
+        )
+        .await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/validate_proof_with_age.rs
+++ b/tests/validate_proof_with_age.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use std::time::Instant;
+use testcontainers::clients::Cli;
 
 use common::prelude::*;
 
@@ -20,8 +21,9 @@ async fn validate_proof_with_age() -> anyhow::Result<()> {
     #[allow(clippy::cast_possible_truncation)]
     let batch_size = 3;
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, _deletion_prover_map, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8).await?;
+        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/validate_proofs.rs
+++ b/tests/validate_proofs.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use common::prelude::*;
-use testcontainers::clients::Cli;
 
 #[tokio::test]
 async fn validate_proofs() -> anyhow::Result<()> {
@@ -17,8 +16,14 @@ async fn validate_proofs() -> anyhow::Result<()> {
     let batch_size = 3;
 
     let docker = Cli::default();
-    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
+    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
+        initial_root,
+        &[batch_size],
+        &[],
+        DEFAULT_TREE_DEPTH as u8,
+        &docker,
+    )
+    .await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 

--- a/tests/validate_proofs.rs
+++ b/tests/validate_proofs.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::prelude::*;
+use testcontainers::clients::Cli;
 
 #[tokio::test]
 async fn validate_proofs() -> anyhow::Result<()> {
@@ -15,8 +16,9 @@ async fn validate_proofs() -> anyhow::Result<()> {
 
     let batch_size = 3;
 
+    let docker = Cli::default();
     let (mock_chain, db_container, insertion_prover_map, _, micro_oz) =
-        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8).await?;
+        spawn_deps(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8, &docker).await?;
 
     let prover_mock = &insertion_prover_map[&batch_size];
 


### PR DESCRIPTION
## Motivation

As discussed:
There was a bug (docker containers running after tests) in docker wrapper and to follow direction from other projects testcontainers was introduced here instead. Docker image of postgres is being used for testing. Question: which version of postgres is being used? I think it should match the version running in prod env.
There was also a bug in shutdown testing. Tests were interfering due to shutdown being called twice (once from one test and second time from the other). It was causing panic, which was causing process abort (due to rust configuration in Cargo.toml), which was causing strange/hard to understand test results (random tests being red without any special error). This test was disabled for now.

## Solution

Introduced testcontainers. Disabled shutdown test.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation

