### PR TITLE
feat: report identity queue length on a timer. [PRO-588]

### DIFF
--- a/src/task_monitor/tasks/finalize_identities.rs
+++ b/src/task_monitor/tasks/finalize_identities.rs
@@ -16,7 +16,6 @@ use crate::contracts::scanner::BlockScanner;
 use crate::contracts::IdentityManager;
 use crate::database::{Database, DatabaseExt as _};
 use crate::identity_tree::{Canonical, Intermediate, TreeVersion, TreeWithNextVersion};
-use crate::task_monitor::TaskMonitor;
 
 pub async fn finalize_roots(app: Arc<App>) -> anyhow::Result<()> {
     let mainnet_abi = app.identity_manager.abi();
@@ -159,8 +158,6 @@ async fn finalize_mainnet_roots(
         let updates_count = processed_tree.apply_updates_up_to(post_root.into());
 
         info!(updates_count, ?pre_root, ?post_root, "Mined tree updated");
-
-        TaskMonitor::log_identities_queues(database).await?;
     }
 
     Ok(())

--- a/src/task_monitor/tasks/mod.rs
+++ b/src/task_monitor/tasks/mod.rs
@@ -1,5 +1,6 @@
 pub mod delete_identities;
 pub mod finalize_identities;
 pub mod insert_identities;
+pub mod monitor_queue;
 pub mod monitor_txs;
 pub mod process_identities;

--- a/src/task_monitor/tasks/monitor_queue.rs
+++ b/src/task_monitor/tasks/monitor_queue.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+use tokio::time::{sleep, Duration};
+
+use crate::task_monitor::{App, TaskMonitor};
+
+// How often send metrics for idenity queue length
+const QUEUE_MONITORING_PERIOD: Duration = Duration::from_secs(1);
+
+pub async fn monitor_queue(app: Arc<App>) -> anyhow::Result<()> {
+    loop {
+        TaskMonitor::log_identities_queues(&app.database).await?;
+        sleep(QUEUE_MONITORING_PERIOD).await;
+    }
+}


### PR DESCRIPTION
Spawn a task which reports length of the identity queue in the db.


## Motivation

The queue length is only reported when a new block is submitted to the blockchain which is in-frequent.

## Solution

Spawn a task to report the queue length every second.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation

