### PR TITLE
Added batching using DB.

### DIFF
--- a/schemas/database/013_batches_and_transactions.sql
+++ b/schemas/database/013_batches_and_transactions.sql
@@ -1,0 +1,24 @@
+-- Create ENUM for prover type
+CREATE TABLE batches
+(
+    id         BIGSERIAL UNIQUE PRIMARY KEY,
+    next_root  BYTEA       NOT NULL UNIQUE,
+    prev_root  BYTEA UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL,
+    batch_type VARCHAR(50) NOT NULL,
+    data       JSON        NOT NULL,
+
+    FOREIGN KEY (prev_root) REFERENCES batches (next_root) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_batches_prev_root ON batches (prev_root);
+CREATE UNIQUE INDEX i_single_null_prev_root ON batches ((batches.prev_root IS NULL)) WHERE batches.prev_root IS NULL;
+
+CREATE TABLE transactions
+(
+    transaction_id  VARCHAR(256) NOT NULL UNIQUE PRIMARY KEY,
+    batch_next_root BYTEA        NOT NULL UNIQUE,
+    created_at      TIMESTAMPTZ  NOT NULL,
+
+    FOREIGN KEY (batch_next_root) REFERENCES batches (next_root) ON DELETE CASCADE
+);

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ use crate::database::Database;
 use crate::ethereum::Ethereum;
 use crate::identity_tree::{
     CanonicalTreeBuilder, Hash, InclusionProof, ProcessedStatus, RootItem, Status, TreeState,
-    TreeUpdate, TreeVersionReadOps, UnprocessedStatus,
+    TreeUpdate, TreeVersionReadOps, TreeWithNextVersion, UnprocessedStatus,
 };
 use crate::prover::map::initialize_prover_maps;
 use crate::prover::{ProverConfig, ProverType};
@@ -114,10 +114,12 @@ impl App {
             // Note that we don't have a way of queuing a root here for finalization.
             // so it's going to stay as "processed" until the next root is mined.
             self.database.mark_root_as_processed_tx(&root_hash).await?;
+            self.database.delete_batches_after_root(&root_hash).await?;
         } else {
             // Db is either empty or we're restarting with a new contract/chain
             // so we should mark everything as pending
             self.database.mark_all_as_pending().await?;
+            self.database.delete_all_batches().await?;
         }
 
         let timer = Instant::now();
@@ -263,6 +265,9 @@ impl App {
 
         let (processed, batching_builder) = processed_builder.seal_and_continue();
         let (batching, mut latest_builder) = batching_builder.seal_and_continue();
+
+        // We are duplicating updates here for some commitments that were batched but
+        // this is an idempotent operation
         let pending_items = self
             .database
             .get_commitments_by_status(ProcessedStatus::Pending)
@@ -271,6 +276,15 @@ impl App {
             latest_builder.update(&update);
         }
         let latest = latest_builder.seal();
+
+        let batch = self.database.get_latest_batch().await?;
+        if let Some(batch) = batch {
+            if batching.get_root() != batch.next_root {
+                batching.apply_updates_up_to(batch.next_root);
+            }
+            assert_eq!(batching.get_root(), batch.next_root);
+        }
+
         Ok(Some(TreeState::new(mined, processed, batching, latest)))
     }
 
@@ -356,6 +370,14 @@ impl App {
         .await?;
 
         let latest = latest_builder.seal();
+
+        let batch = self.database.get_latest_batch().await?;
+        if let Some(batch) = batch {
+            if batching.get_root() != batch.next_root {
+                batching.apply_updates_up_to(batch.next_root);
+            }
+            assert_eq!(batching.get_root(), batch.next_root);
+        }
 
         Ok(TreeState::new(mined, processed, batching, latest))
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -266,8 +266,6 @@ impl App {
         let (processed, batching_builder) = processed_builder.seal_and_continue();
         let (batching, mut latest_builder) = batching_builder.seal_and_continue();
 
-        // We are duplicating updates here for some commitments that were batched but
-        // this is an idempotent operation
         let pending_items = self
             .database
             .get_commitments_by_status(ProcessedStatus::Pending)

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -17,8 +17,6 @@ use tracing::{error, info, instrument, warn};
 use crate::config::DatabaseConfig;
 use crate::database::query::DatabaseQuery;
 use crate::identity_tree::Hash;
-use crate::prover::identity::Identity;
-use crate::prover::{ProverConfig, ProverType};
 
 pub mod query;
 pub mod transaction;

--- a/src/database/query.rs
+++ b/src/database/query.rs
@@ -6,10 +6,12 @@ use sqlx::{Executor, Postgres, Row};
 use tracing::instrument;
 use types::{DeletionEntry, LatestDeletionEntry, RecoveryEntry};
 
+use crate::database::types::{BatchEntry, BatchEntryData, BatchType, TransactionEntry};
 use crate::database::{types, Error};
 use crate::identity_tree::{
     Hash, ProcessedStatus, RootItem, TreeItem, TreeUpdate, UnprocessedStatus,
 };
+use crate::prover::identity::Identity;
 use crate::prover::{ProverConfig, ProverType};
 
 const MAX_UNPROCESSED_FETCH_COUNT: i64 = 10_000;
@@ -541,5 +543,266 @@ pub trait DatabaseQuery<'a>: Executor<'a, Database = Postgres> {
                 .bind(commitment);
         let row_unprocessed = self.fetch_one(query_queued_deletion).await?;
         Ok(row_unprocessed.get::<bool, _>(0))
+    }
+
+    async fn insert_new_batch_head(self, next_root: &Hash) -> Result<(), Error> {
+        let query = sqlx::query(
+            r#"
+            INSERT INTO batches(
+                id,
+                next_root,
+                prev_root,
+                created_at,
+                batch_type,
+                data
+            ) VALUES (DEFAULT, $1, NULL, CURRENT_TIMESTAMP, $2, $3)
+            "#,
+        )
+        .bind(next_root)
+        .bind(BatchType::Insertion)
+        .bind(sqlx::types::Json::from(BatchEntryData {
+            identities: vec![],
+            indexes:    vec![],
+        }));
+
+        self.execute(query).await?;
+        Ok(())
+    }
+
+    async fn insert_new_batch(
+        self,
+        next_root: &Hash,
+        prev_root: &Hash,
+        batch_type: BatchType,
+        identities: &[Identity],
+        indexes: &[usize],
+    ) -> Result<(), Error> {
+        let query = sqlx::query(
+            r#"
+            INSERT INTO batches(
+                id,
+                next_root,
+                prev_root,
+                created_at,
+                batch_type,
+                data
+            ) VALUES (DEFAULT, $1, $2, CURRENT_TIMESTAMP, $3, $4)
+            "#,
+        )
+        .bind(next_root)
+        .bind(prev_root)
+        .bind(batch_type)
+        .bind(sqlx::types::Json::from(BatchEntryData {
+            identities: identities.to_vec(),
+            indexes:    indexes.to_vec(),
+        }));
+
+        self.execute(query).await?;
+        Ok(())
+    }
+
+    async fn get_next_batch(self, prev_root: &Hash) -> Result<Option<BatchEntry>, Error> {
+        let res = sqlx::query_as::<_, BatchEntry>(
+            r#"
+            SELECT
+                id,
+                next_root,
+                prev_root,
+                created_at,
+                batch_type,
+                data
+            FROM batches WHERE prev_root = $1
+            LIMIT 1
+            "#,
+        )
+        .bind(prev_root)
+        .fetch_optional(self)
+        .await?;
+
+        Ok(res)
+    }
+
+    async fn get_latest_batch(self) -> Result<Option<BatchEntry>, Error> {
+        let res = sqlx::query_as::<_, BatchEntry>(
+            r#"
+            SELECT
+                id,
+                next_root,
+                prev_root,
+                created_at,
+                batch_type,
+                data
+            FROM batches
+            ORDER BY id DESC
+            LIMIT 1
+            "#,
+        )
+        .fetch_optional(self)
+        .await?;
+
+        Ok(res)
+    }
+
+    async fn get_latest_batch_with_transaction(self) -> Result<Option<BatchEntry>, Error> {
+        let res = sqlx::query_as::<_, BatchEntry>(
+            r#"
+            SELECT
+                batches.id,
+                batches.next_root,
+                batches.prev_root,
+                batches.created_at,
+                batches.batch_type,
+                batches.data
+            FROM batches
+            LEFT JOIN transactions ON batches.next_root = transactions.batch_next_root
+            WHERE transactions.batch_next_root IS NOT NULL AND batches.prev_root IS NOT NULL
+            ORDER BY batches.id DESC
+            LIMIT 1
+            "#,
+        )
+        .fetch_optional(self)
+        .await?;
+
+        Ok(res)
+    }
+
+    async fn get_next_batch_without_transaction(self) -> Result<Option<BatchEntry>, Error> {
+        let res = sqlx::query_as::<_, BatchEntry>(
+            r#"
+            SELECT
+                batches.id,
+                batches.next_root,
+                batches.prev_root,
+                batches.created_at,
+                batches.batch_type,
+                batches.data
+            FROM batches
+            LEFT JOIN transactions ON batches.next_root = transactions.batch_next_root
+            WHERE transactions.batch_next_root IS NULL AND batches.prev_root IS NOT NULL
+            ORDER BY batches.id ASC
+            LIMIT 1
+            "#,
+        )
+        .fetch_optional(self)
+        .await?;
+
+        Ok(res)
+    }
+
+    async fn get_batch_head(self) -> Result<Option<BatchEntry>, Error> {
+        let res = sqlx::query_as::<_, BatchEntry>(
+            r#"
+            SELECT
+                id,
+                next_root,
+                prev_root,
+                created_at,
+                batch_type,
+                data
+            FROM batches WHERE prev_root IS NULL
+            LIMIT 1
+            "#,
+        )
+        .fetch_optional(self)
+        .await?;
+
+        Ok(res)
+    }
+
+    async fn get_all_batches_after(self, id: i64) -> Result<Vec<BatchEntry>, Error> {
+        let res = sqlx::query_as::<_, BatchEntry>(
+            r#"
+            SELECT
+                id,
+                next_root,
+                prev_root,
+                created_at,
+                batch_type,
+                data
+            FROM batches WHERE id >= $1 ORDER BY id ASC
+            "#,
+        )
+        .bind(id)
+        .fetch_all(self)
+        .await?;
+
+        Ok(res)
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn delete_batches_after_root(self, root: &Hash) -> Result<(), Error> {
+        let query = sqlx::query(
+            r#"
+            DELETE FROM batches
+            WHERE prev_root = $1
+            "#,
+        )
+        .bind(root);
+
+        self.execute(query).await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn delete_all_batches(self) -> Result<(), Error> {
+        let query = sqlx::query(
+            r#"
+            DELETE FROM batches
+            "#,
+        );
+
+        self.execute(query).await?;
+        Ok(())
+    }
+
+    async fn root_in_batch_chain(self, root: &Hash) -> Result<bool, Error> {
+        let query = sqlx::query(
+            r#"SELECT exists(SELECT 1 FROM batches where prev_root = $1 OR next_root = $1)"#,
+        )
+        .bind(root);
+        let row_unprocessed = self.fetch_one(query).await?;
+        Ok(row_unprocessed.get::<bool, _>(0))
+    }
+
+    async fn insert_new_transaction(
+        self,
+        transaction_id: &String,
+        batch_next_root: &Hash,
+    ) -> Result<(), Error> {
+        let query = sqlx::query(
+            r#"
+            INSERT INTO transactions(
+                transaction_id,
+                batch_next_root,
+                created_at
+            ) VALUES ($1, $2, CURRENT_TIMESTAMP)
+            "#,
+        )
+        .bind(transaction_id)
+        .bind(batch_next_root);
+
+        self.execute(query).await?;
+        Ok(())
+    }
+
+    async fn get_transaction_for_batch(
+        self,
+        next_root: &Hash,
+    ) -> Result<Option<TransactionEntry>, Error> {
+        let res = sqlx::query_as::<_, TransactionEntry>(
+            r#"
+            SELECT
+                transaction_id,
+                batch_next_root,
+                created_at
+            FROM transactions WHERE batch_next_root = $1
+            LIMIT 1
+            "#,
+        )
+        .bind(next_root)
+        .fetch_optional(self)
+        .await?;
+
+        Ok(res)
     }
 }

--- a/src/database/types.rs
+++ b/src/database/types.rs
@@ -1,7 +1,13 @@
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::database::{HasArguments, HasValueRef};
+use sqlx::encode::IsNull;
+use sqlx::error::BoxDynError;
 use sqlx::prelude::FromRow;
+use sqlx::{Decode, Encode, Postgres, Type};
 
 use crate::identity_tree::{Hash, Status, UnprocessedStatus};
+use crate::prover::identity::Identity;
 
 pub struct UnprocessedCommitment {
     pub commitment:            Hash,
@@ -36,4 +42,138 @@ pub struct CommitmentHistoryEntry {
     // set to true if the eligibility timestamp is in the future
     pub held_back:  bool,
     pub status:     Status,
+}
+
+#[derive(Debug, Copy, Clone, sqlx::Type, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[sqlx(type_name = "VARCHAR", rename_all = "PascalCase")]
+pub enum BatchType {
+    #[default]
+    Insertion,
+    Deletion,
+}
+
+impl From<String> for BatchType {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "Insertion" => BatchType::Insertion,
+            "Deletion" => BatchType::Deletion,
+            _ => BatchType::Insertion,
+        }
+    }
+}
+
+impl std::fmt::Display for BatchType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            BatchType::Insertion => write!(f, "insertion"),
+            BatchType::Deletion => write!(f, "deletion"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct BatchEntry {
+    pub id:         i64,
+    pub next_root:  Hash,
+    // In general prev_root is present all the time except the first row (head of the batches
+    // chain)
+    pub prev_root:  Option<Hash>,
+    pub created_at: DateTime<Utc>,
+    pub batch_type: BatchType,
+    pub data:       sqlx::types::Json<BatchEntryData>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BatchEntryData {
+    pub identities: Vec<Identity>,
+    pub indexes:    Vec<usize>,
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct TransactionEntry {
+    pub batch_next_root: Hash,
+    pub transaction_id:  String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Commitments(pub Vec<Hash>);
+
+impl Encode<'_, Postgres> for Commitments {
+    fn encode_by_ref(&self, buf: &mut <Postgres as HasArguments<'_>>::ArgumentBuffer) -> IsNull {
+        let commitments = &self
+            .0
+            .iter()
+            .map(|c| c.to_be_bytes()) // Why be not le?
+            .collect::<Vec<[u8; 32]>>();
+
+        <&Vec<[u8; 32]> as Encode<Postgres>>::encode(commitments, buf)
+    }
+}
+
+impl Decode<'_, Postgres> for Commitments {
+    fn decode(value: <Postgres as HasValueRef<'_>>::ValueRef) -> Result<Self, BoxDynError> {
+        let value = <Vec<[u8; 32]> as Decode<Postgres>>::decode(value)?;
+
+        let res = value.iter().map(|&v| Hash::from_be_bytes(v)).collect();
+
+        Ok(Commitments(res))
+    }
+}
+
+impl Type<Postgres> for Commitments {
+    fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+        <&Vec<&[u8]> as Type<Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &<Postgres as sqlx::Database>::TypeInfo) -> bool {
+        <&Vec<&[u8]> as Type<Postgres>>::compatible(ty)
+    }
+}
+
+impl From<Vec<Hash>> for Commitments {
+    fn from(value: Vec<Hash>) -> Self {
+        Commitments(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeafIndexes(pub Vec<usize>);
+
+impl Encode<'_, Postgres> for LeafIndexes {
+    fn encode_by_ref(&self, buf: &mut <Postgres as HasArguments<'_>>::ArgumentBuffer) -> IsNull {
+        let commitments = &self
+            .0
+            .iter()
+            .map(|&c| c as i64) // Why be not le?
+            .collect();
+
+        <&Vec<i64> as Encode<Postgres>>::encode(commitments, buf)
+    }
+}
+
+impl Decode<'_, Postgres> for LeafIndexes {
+    fn decode(value: <Postgres as HasValueRef<'_>>::ValueRef) -> Result<Self, BoxDynError> {
+        let value = <Vec<i64> as Decode<Postgres>>::decode(value)?;
+
+        let res = value.iter().map(|&v| v as usize).collect();
+
+        Ok(LeafIndexes(res))
+    }
+}
+
+impl Type<Postgres> for LeafIndexes {
+    fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+        <&Vec<i64> as Type<Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &<Postgres as sqlx::Database>::TypeInfo) -> bool {
+        <&Vec<i64> as Type<Postgres>>::compatible(ty)
+    }
+}
+
+impl From<Vec<usize>> for LeafIndexes {
+    fn from(value: Vec<usize>) -> Self {
+        LeafIndexes(value)
+    }
 }

--- a/src/prover/identity.rs
+++ b/src/prover/identity.rs
@@ -1,8 +1,9 @@
 use ethers::types::U256;
+use serde::{Deserialize, Serialize};
 
 /// A representation of an identity insertion into the merkle tree as used for
 /// the prover endpoint.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Identity {
     /// The identity commitment value that is inserted into the merkle tree.
     pub commitment: U256,

--- a/src/task_monitor.rs
+++ b/src/task_monitor.rs
@@ -143,13 +143,37 @@ impl TaskMonitor {
         handles.push(queue_monitor_handle);
 
         // Process identities
+        let base_next_batch_notify = Arc::new(Notify::new());
+
+        // Create batches
         let app = self.app.clone();
+        let next_batch_notify = base_next_batch_notify.clone();
+        let wake_up_notify = base_wake_up_notify.clone();
+
+        let create_batches = move || {
+            tasks::create_batches::create_batches(
+                app.clone(),
+                next_batch_notify.clone(),
+                wake_up_notify.clone(),
+            )
+        };
+        let create_batches_handle = crate::utils::spawn_monitored_with_backoff(
+            create_batches,
+            shutdown_sender.clone(),
+            PROCESS_IDENTITIES_BACKOFF,
+        );
+        handles.push(create_batches_handle);
+
+        // Process batches
+        let app = self.app.clone();
+        let next_batch_notify = base_next_batch_notify.clone();
         let wake_up_notify = base_wake_up_notify.clone();
 
         let process_identities = move || {
-            tasks::process_identities::process_identities(
+            tasks::process_batches::process_batches(
                 app.clone(),
                 monitored_txs_sender.clone(),
+                next_batch_notify.clone(),
                 wake_up_notify.clone(),
             )
         };

--- a/src/task_monitor/tasks/create_batches.rs
+++ b/src/task_monitor/tasks/create_batches.rs
@@ -13,7 +13,8 @@ use tracing::instrument;
 use crate::app::App;
 use crate::contracts::IdentityManager;
 use crate::database;
-use crate::database::{Database, DatabaseQuery as _};
+use crate::database::query::DatabaseQuery as _;
+use crate::database::Database;
 use crate::identity_tree::{
     AppliedTreeUpdate, Hash, Intermediate, TreeVersion, TreeVersionReadOps, TreeWithNextVersion,
 };

--- a/src/task_monitor/tasks/mod.rs
+++ b/src/task_monitor/tasks/mod.rs
@@ -1,6 +1,7 @@
+pub mod create_batches;
 pub mod delete_identities;
 pub mod finalize_identities;
 pub mod insert_identities;
 pub mod monitor_queue;
 pub mod monitor_txs;
-pub mod process_identities;
+pub mod process_batches;

--- a/src/task_monitor/tasks/process_batches.rs
+++ b/src/task_monitor/tasks/process_batches.rs
@@ -1,0 +1,203 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use ethers::types::U256;
+use tokio::sync::{mpsc, Notify};
+use tokio::{select, time};
+use tracing::instrument;
+
+use crate::app::App;
+use crate::contracts::IdentityManager;
+use crate::database::types::{BatchEntry, BatchType};
+use crate::database::DatabaseExt as _;
+use crate::ethereum::write::TransactionId;
+use crate::prover::Prover;
+use crate::utils::index_packing::pack_indices;
+
+pub async fn process_batches(
+    app: Arc<App>,
+    monitored_txs_sender: Arc<mpsc::Sender<TransactionId>>,
+    next_batch_notify: Arc<Notify>,
+    wake_up_notify: Arc<Notify>,
+) -> anyhow::Result<()> {
+    tracing::info!("Awaiting for a clean slate");
+    app.identity_manager.await_clean_slate().await?;
+
+    tracing::info!("Starting identity processor.");
+
+    // We start a timer and force it to perform one initial tick to avoid an
+    // immediate trigger.
+    let mut timer = time::interval(Duration::from_secs(5));
+
+    loop {
+        // We wait either for a timer tick or a full batch
+        select! {
+            _ = timer.tick() => {
+                tracing::info!("Identity batch insertion woken due to timeout");
+            }
+
+            () = next_batch_notify.notified() => {
+                tracing::trace!("Identity batch insertion woken due to next batch creation");
+            },
+
+            () = wake_up_notify.notified() => {
+                tracing::trace!("Identity batch insertion woken due to request");
+            },
+        }
+
+        let next_batch = app.database.get_next_batch_without_transaction().await?;
+        let Some(next_batch) = next_batch else {
+            continue;
+        };
+
+        let tx_id =
+            commit_identities(&app.identity_manager, &monitored_txs_sender, &next_batch).await?;
+
+        if let Some(tx_id) = tx_id {
+            app.database
+                .insert_new_transaction(&tx_id.0, &next_batch.next_root)
+                .await?;
+        }
+
+        // We want to check if there's a full batch available immediately
+        wake_up_notify.notify_one();
+    }
+}
+
+async fn commit_identities(
+    identity_manager: &IdentityManager,
+    monitored_txs_sender: &mpsc::Sender<TransactionId>,
+    batch: &BatchEntry,
+) -> anyhow::Result<Option<TransactionId>> {
+    // If the update is an insertion
+    let tx_id = if batch.batch_type == BatchType::Insertion {
+        let prover = identity_manager
+            .get_suitable_insertion_prover(batch.data.0.identities.len())
+            .await?;
+
+        tracing::info!(
+            num_updates = batch.data.0.identities.len(),
+            batch_size = prover.batch_size(),
+            "Insertion batch",
+        );
+
+        insert_identities(identity_manager, &prover, batch).await?
+    } else {
+        let prover = identity_manager
+            .get_suitable_deletion_prover(batch.data.0.identities.len())
+            .await?;
+
+        tracing::info!(
+            num_updates = batch.data.0.identities.len(),
+            batch_size = prover.batch_size(),
+            "Deletion batch"
+        );
+
+        delete_identities(identity_manager, &prover, batch).await?
+    };
+
+    if let Some(tx_id) = tx_id.clone() {
+        monitored_txs_sender.send(tx_id).await?;
+    }
+
+    Ok(tx_id)
+}
+
+#[instrument(level = "info", skip_all)]
+pub async fn insert_identities(
+    identity_manager: &IdentityManager,
+    prover: &Prover,
+    batch: &BatchEntry,
+) -> anyhow::Result<Option<TransactionId>> {
+    identity_manager.validate_merkle_proofs(&batch.data.0.identities)?;
+    let start_index = *batch.data.0.indexes.first().expect("Should exist.");
+    let pre_root: U256 = batch.prev_root.expect("Should exist.").into();
+    let post_root: U256 = batch.next_root.into();
+
+    // We prepare the proof before reserving a slot in the pending identities
+    let proof = IdentityManager::prepare_insertion_proof(
+        prover,
+        start_index,
+        pre_root,
+        &batch.data.0.identities,
+        post_root,
+    )
+    .await?;
+
+    tracing::info!(
+        start_index,
+        ?pre_root,
+        ?post_root,
+        "Submitting insertion batch"
+    );
+
+    // With all the data prepared we can submit the identities to the on-chain
+    // identity manager and wait for that transaction to be mined.
+    let transaction_id = identity_manager
+        .register_identities(
+            start_index,
+            pre_root,
+            post_root,
+            batch.data.0.identities.clone(),
+            proof,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "Failed to insert identity to contract.");
+            e
+        })?;
+
+    tracing::info!(
+        start_index,
+        ?pre_root,
+        ?post_root,
+        ?transaction_id,
+        "Insertion batch submitted"
+    );
+
+    Ok(Some(transaction_id))
+}
+
+pub async fn delete_identities(
+    identity_manager: &IdentityManager,
+    prover: &Prover,
+    batch: &BatchEntry,
+) -> anyhow::Result<Option<TransactionId>> {
+    identity_manager.validate_merkle_proofs(&batch.data.0.identities)?;
+    let pre_root: U256 = batch.prev_root.expect("Should exist.").into();
+    let post_root: U256 = batch.next_root.into();
+    let deletion_indices: Vec<_> = batch.data.0.indexes.iter().map(|&v| v as u32).collect();
+
+    // We prepare the proof before reserving a slot in the pending identities
+    let proof = IdentityManager::prepare_deletion_proof(
+        prover,
+        pre_root,
+        deletion_indices.clone(),
+        batch.data.0.identities.clone(),
+        post_root,
+    )
+    .await?;
+
+    let packed_deletion_indices = pack_indices(&deletion_indices);
+
+    tracing::info!(?pre_root, ?post_root, "Submitting deletion batch");
+
+    // With all the data prepared we can submit the identities to the on-chain
+    // identity manager and wait for that transaction to be mined.
+    let transaction_id = identity_manager
+        .delete_identities(proof, packed_deletion_indices, pre_root, post_root)
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "Failed to insert identity to contract.");
+            e
+        })?;
+
+    tracing::info!(
+        ?pre_root,
+        ?post_root,
+        ?transaction_id,
+        "Deletion batch submitted"
+    );
+
+    Ok(Some(transaction_id))
+}

--- a/src/task_monitor/tasks/process_batches.rs
+++ b/src/task_monitor/tasks/process_batches.rs
@@ -8,8 +8,8 @@ use tracing::instrument;
 
 use crate::app::App;
 use crate::contracts::IdentityManager;
+use crate::database::query::DatabaseQuery as _;
 use crate::database::types::{BatchEntry, BatchType};
-use crate::database::DatabaseExt as _;
 use crate::ethereum::write::TransactionId;
 use crate::prover::Prover;
 use crate::utils::index_packing::pack_indices;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -64,6 +64,7 @@ pub mod prelude {
         spawn_mock_insertion_prover, test_inclusion_proof, test_insert_identity, test_verify_proof,
         test_verify_proof_on_chain,
     };
+    pub use crate::common::chain_mock::spawn_mock_chain;
     pub use crate::common::test_same_tree_states;
 }
 
@@ -747,7 +748,7 @@ pub async fn spawn_deps<'a, 'b, 'c>(
     ))
 }
 
-async fn spawn_db(docker: &Cli) -> anyhow::Result<DockerContainer<'_>> {
+async fn spawn_db(docker: &Cli) -> anyhow::Result<DockerContainer> {
     let db_container = postgres_docker_utils::setup(docker).await.unwrap();
 
     Ok(db_container)

--- a/tests/tree_restore_multiple_commitments.rs
+++ b/tests/tree_restore_multiple_commitments.rs
@@ -5,7 +5,7 @@ use common::prelude::*;
 const IDLE_TIME: u64 = 7;
 
 #[tokio::test]
-async fn tree_restore_multiple_comittments() -> anyhow::Result<()> {
+async fn tree_restore_multiple_commitments() -> anyhow::Result<()> {
     // Initialize logging for the test.
     init_tracing_subscriber();
     info!("Starting integration test");

--- a/tests/tree_restore_one_commitment.rs
+++ b/tests/tree_restore_one_commitment.rs
@@ -5,7 +5,7 @@ use common::prelude::*;
 const IDLE_TIME: u64 = 7;
 
 #[tokio::test]
-async fn tree_restore_one_comittment() -> anyhow::Result<()> {
+async fn tree_restore_one_commitment() -> anyhow::Result<()> {
     // Initialize logging for the test.
     init_tracing_subscriber();
     info!("Starting integration test");

--- a/tests/tree_restore_with_root_back_to_init.rs
+++ b/tests/tree_restore_with_root_back_to_init.rs
@@ -1,0 +1,202 @@
+mod common;
+
+use common::prelude::*;
+
+const IDLE_TIME: u64 = 7;
+
+#[tokio::test]
+async fn tree_restore_with_root_back_to_init() -> anyhow::Result<()> {
+    // Initialize logging for the test.
+    init_tracing_subscriber();
+    info!("Starting integration test");
+
+    let batch_size: usize = 3;
+
+    let mut ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
+    let initial_root: U256 = ref_tree.root().into();
+
+    let docker = Cli::default();
+    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
+        initial_root,
+        &[batch_size],
+        &[],
+        DEFAULT_TREE_DEPTH as u8,
+        &docker,
+    )
+    .await?;
+
+    let prover_mock = &insertion_prover_map[&batch_size];
+
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
+
+    // temp dir will be deleted on drop call
+    let temp_dir = tempfile::tempdir()?;
+    info!(
+        "temp dir created at: {:?}",
+        temp_dir.path().join("testfile")
+    );
+
+    let config = TestConfigBuilder::new()
+        .db_url(&db_url)
+        .oz_api_url(&micro_oz.endpoint())
+        .oz_address(micro_oz.address())
+        .identity_manager_address(mock_chain.identity_manager.address())
+        .primary_network_provider(mock_chain.anvil.endpoint())
+        .cache_file(temp_dir.path().join("testfile").to_str().unwrap())
+        .add_prover(prover_mock)
+        .build()?;
+
+    let (app, app_handle, local_addr) = spawn_app(config.clone())
+        .await
+        .expect("Failed to spawn app.");
+
+    let test_identities = generate_test_identities(3);
+    let identities_ref: Vec<Field> = test_identities
+        .iter()
+        .map(|i| Hash::from_str_radix(i, 16).unwrap())
+        .collect();
+
+    let uri = "http://".to_owned() + &local_addr.to_string();
+    let client = Client::new();
+
+    test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, 0).await;
+    test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, 1).await;
+    test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, 2).await;
+
+    tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
+
+    // Check that we can also get these inclusion proofs back.
+    test_inclusion_proof(
+        &uri,
+        &client,
+        0,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[0], 16)
+            .expect("Failed to parse Hash from test leaf 0"),
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &uri,
+        &client,
+        1,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[1], 16)
+            .expect("Failed to parse Hash from test leaf 1"),
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &uri,
+        &client,
+        2,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[2], 16)
+            .expect("Failed to parse Hash from test leaf 2"),
+        false,
+    )
+    .await;
+
+    let tree_state = app.tree_state()?.clone();
+
+    assert_eq!(tree_state.latest_tree().next_leaf(), 3);
+
+    // Shutdown the app and reset the mock shutdown, allowing us to test the
+    // behaviour with saved data.
+    info!("Stopping the app for testing purposes");
+    shutdown();
+    app_handle.await.unwrap();
+    reset_shutdown();
+
+    drop(mock_chain);
+    drop(micro_oz);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let mock_chain =
+        spawn_mock_chain(initial_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8).await?;
+    let micro_oz =
+        micro_oz::spawn(mock_chain.anvil.endpoint(), mock_chain.private_key.clone()).await?;
+
+    let config = TestConfigBuilder::new()
+        .db_url(&db_url)
+        .oz_api_url(&micro_oz.endpoint())
+        .oz_address(micro_oz.address())
+        .identity_manager_address(mock_chain.identity_manager.address())
+        .primary_network_provider(mock_chain.anvil.endpoint())
+        .cache_file(temp_dir.path().join("testfile").to_str().unwrap())
+        .add_prover(prover_mock)
+        .build()?;
+
+    let (app, app_handle, local_addr) = spawn_app(config.clone())
+        .await
+        .expect("Failed to spawn app.");
+
+    let uri = "http://".to_owned() + &local_addr.to_string();
+
+    let restored_tree_state = app.tree_state()?.clone();
+
+    assert_eq!(
+        restored_tree_state.latest_tree().get_root(),
+        tree_state.latest_tree().get_root()
+    );
+    assert_eq!(
+        restored_tree_state.batching_tree().get_root(),
+        initial_root.into()
+    );
+    assert_eq!(
+        restored_tree_state.mined_tree().get_root(),
+        initial_root.into()
+    );
+    assert_eq!(
+        restored_tree_state.processed_tree().get_root(),
+        initial_root.into()
+    );
+
+    tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
+
+    // Check that we can also get these inclusion proofs back.
+    test_inclusion_proof(
+        &uri,
+        &client,
+        0,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[0], 16)
+            .expect("Failed to parse Hash from test leaf 0"),
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &uri,
+        &client,
+        1,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[1], 16)
+            .expect("Failed to parse Hash from test leaf 1"),
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &uri,
+        &client,
+        2,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[2], 16)
+            .expect("Failed to parse Hash from test leaf 2"),
+        false,
+    )
+    .await;
+
+    test_same_tree_states(&tree_state, &restored_tree_state).await?;
+
+    // Shutdown the app properly for the final time
+    shutdown();
+    app_handle.await.unwrap();
+    for (_, prover) in insertion_prover_map.into_iter() {
+        prover.stop();
+    }
+    reset_shutdown();
+
+    Ok(())
+}

--- a/tests/tree_restore_with_root_back_to_middle.rs
+++ b/tests/tree_restore_with_root_back_to_middle.rs
@@ -1,0 +1,239 @@
+mod common;
+
+use common::prelude::*;
+
+const IDLE_TIME: u64 = 7;
+
+#[tokio::test]
+async fn tree_restore_with_root_back_to_middle() -> anyhow::Result<()> {
+    // Initialize logging for the test.
+    init_tracing_subscriber();
+    info!("Starting integration test");
+
+    let batch_size: usize = 3;
+
+    let mut ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
+    let initial_root: U256 = ref_tree.root().into();
+
+    let docker = Cli::default();
+    let (mock_chain, db_container, insertion_prover_map, _, micro_oz) = spawn_deps(
+        initial_root,
+        &[batch_size],
+        &[],
+        DEFAULT_TREE_DEPTH as u8,
+        &docker,
+    )
+    .await?;
+
+    let prover_mock = &insertion_prover_map[&batch_size];
+
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
+
+    // temp dir will be deleted on drop call
+    let temp_dir = tempfile::tempdir()?;
+    info!(
+        "temp dir created at: {:?}",
+        temp_dir.path().join("testfile")
+    );
+
+    let config = TestConfigBuilder::new()
+        .db_url(&db_url)
+        .oz_api_url(&micro_oz.endpoint())
+        .oz_address(micro_oz.address())
+        .identity_manager_address(mock_chain.identity_manager.address())
+        .primary_network_provider(mock_chain.anvil.endpoint())
+        .cache_file(temp_dir.path().join("testfile").to_str().unwrap())
+        .add_prover(prover_mock)
+        .build()?;
+
+    let (app, app_handle, local_addr) = spawn_app(config.clone())
+        .await
+        .expect("Failed to spawn app.");
+
+    let test_identities = generate_test_identities(6);
+    let identities_ref: Vec<Field> = test_identities
+        .iter()
+        .map(|i| Hash::from_str_radix(i, 16).unwrap())
+        .collect();
+
+    let uri = "http://".to_owned() + &local_addr.to_string();
+    let client = Client::new();
+
+    test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, 0).await;
+    test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, 1).await;
+    test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, 2).await;
+
+    tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
+
+    // Check that we can also get these inclusion proofs back.
+    test_inclusion_proof(
+        &uri,
+        &client,
+        0,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[0], 16)
+            .expect("Failed to parse Hash from test leaf 0"),
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &uri,
+        &client,
+        1,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[1], 16)
+            .expect("Failed to parse Hash from test leaf 1"),
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &uri,
+        &client,
+        2,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[2], 16)
+            .expect("Failed to parse Hash from test leaf 2"),
+        false,
+    )
+    .await;
+
+    let mid_root: U256 = ref_tree.root().into();
+
+    test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, 3).await;
+    test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, 4).await;
+    test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, 5).await;
+
+    tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
+
+    // Check that we can also get these inclusion proofs back.
+    test_inclusion_proof(
+        &uri,
+        &client,
+        3,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[3], 16)
+            .expect("Failed to parse Hash from test leaf 3"),
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &uri,
+        &client,
+        4,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[4], 16)
+            .expect("Failed to parse Hash from test leaf 4"),
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &uri,
+        &client,
+        5,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[5], 16)
+            .expect("Failed to parse Hash from test leaf 5"),
+        false,
+    )
+    .await;
+
+    let tree_state = app.tree_state()?.clone();
+
+    assert_eq!(tree_state.latest_tree().next_leaf(), 6);
+
+    // Shutdown the app and reset the mock shutdown, allowing us to test the
+    // behaviour with saved data.
+    info!("Stopping the app for testing purposes");
+    shutdown();
+    app_handle.await.unwrap();
+    reset_shutdown();
+
+    drop(mock_chain);
+    drop(micro_oz);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let mock_chain =
+        spawn_mock_chain(mid_root, &[batch_size], &[], DEFAULT_TREE_DEPTH as u8).await?;
+    let micro_oz =
+        micro_oz::spawn(mock_chain.anvil.endpoint(), mock_chain.private_key.clone()).await?;
+
+    let config = TestConfigBuilder::new()
+        .db_url(&db_url)
+        .oz_api_url(&micro_oz.endpoint())
+        .oz_address(micro_oz.address())
+        .identity_manager_address(mock_chain.identity_manager.address())
+        .primary_network_provider(mock_chain.anvil.endpoint())
+        .cache_file(temp_dir.path().join("testfile").to_str().unwrap())
+        .add_prover(prover_mock)
+        .build()?;
+
+    let (app, app_handle, local_addr) = spawn_app(config.clone())
+        .await
+        .expect("Failed to spawn app.");
+
+    let uri = "http://".to_owned() + &local_addr.to_string();
+
+    let restored_tree_state = app.tree_state()?.clone();
+
+    assert_eq!(
+        restored_tree_state.latest_tree().get_root(),
+        tree_state.latest_tree().get_root()
+    );
+    assert_eq!(
+        restored_tree_state.batching_tree().get_root(),
+        mid_root.into()
+    );
+    assert_eq!(restored_tree_state.mined_tree().get_root(), mid_root.into());
+    assert_eq!(
+        restored_tree_state.processed_tree().get_root(),
+        mid_root.into()
+    );
+
+    tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
+
+    // Check that we can also get these inclusion proofs back.
+    test_inclusion_proof(
+        &uri,
+        &client,
+        3,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[3], 16)
+            .expect("Failed to parse Hash from test leaf 3"),
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &uri,
+        &client,
+        4,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[4], 16)
+            .expect("Failed to parse Hash from test leaf 4"),
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &uri,
+        &client,
+        5,
+        &ref_tree,
+        &Hash::from_str_radix(&test_identities[5], 16)
+            .expect("Failed to parse Hash from test leaf 5"),
+        false,
+    )
+    .await;
+
+    test_same_tree_states(&tree_state, &restored_tree_state).await?;
+
+    // Shutdown the app properly for the final time
+    shutdown();
+    app_handle.await.unwrap();
+    for (_, prover) in insertion_prover_map.into_iter() {
+        prover.stop();
+    }
+    reset_shutdown();
+
+    Ok(())
+}


### PR DESCRIPTION
This is a first step to introduce batches and transactions table. This is not HA solution yet - just the first step towards it.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Make small changes instead of one big.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Now processing batches is changed into 2 steps. First one is to create a batch (select identities, leaf indexes, etc.). Then the batch is saved in database. Second step is reading data from database (batch) and executes it. Proper batch execution includes storing transaction id in database.

As an alternative solution we could save in database a batch with a proves (no need to calculate it later). It will allow second step (transaction creation/execution) to not use any tree at all. It will require more memory used in database (it can be cleared from time to time as we don't need all the batches forever) but will make HA solution much easier.

This version is also removing batches/transactions when identities are again marked as pending.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
