### PR TITLE
Remove status field from all responses.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,6 +1984,7 @@ dependencies = [
  "anyhow",
  "ethers",
  "hex",
+ "hex-literal",
  "hyper",
  "rand",
  "retry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,7 @@ dependencies = [
  "hyper",
  "rand",
  "retry",
+ "serde",
  "serde_json",
  "signup-sequencer",
  "tokio",

--- a/e2e_tests/scenarios/Cargo.toml
+++ b/e2e_tests/scenarios/Cargo.toml
@@ -17,6 +17,7 @@ signup-sequencer = { path = "./../.." }
 anyhow = "1.0"
 ethers = { version = "2.0.10" }
 hex = "0.4.3"
+hex-literal = "0.4.1"
 hyper = { version = "^0.14.17", features = ["tcp", "http1", "http2", "client"] }
 rand = "0.8.5"
 retry = "2.0.0"

--- a/e2e_tests/scenarios/Cargo.toml
+++ b/e2e_tests/scenarios/Cargo.toml
@@ -20,6 +20,7 @@ hex = "0.4.3"
 hyper = { version = "^0.14.17", features = ["tcp", "http1", "http2", "client"] }
 rand = "0.8.5"
 retry = "2.0.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"

--- a/e2e_tests/scenarios/tests/common/abi.rs
+++ b/e2e_tests/scenarios/tests/common/abi.rs
@@ -3,7 +3,7 @@
 use ethers::prelude::abigen;
 
 abigen!(
-    IdentityManagerContract,
+    IWorldIDIdentityManager,
     r#"[
         struct RootInfo { uint256 root; uint128 supersededTimestamp; bool isValid }
         function queryRoot(uint256 root) public view virtual returns (RootInfo memory)

--- a/e2e_tests/scenarios/tests/common/abi.rs
+++ b/e2e_tests/scenarios/tests/common/abi.rs
@@ -1,0 +1,12 @@
+#![allow(clippy::extra_unused_lifetimes)]
+
+use ethers::prelude::abigen;
+
+abigen!(
+    IdentityManagerContract,
+    r#"[
+        struct RootInfo { uint256 root; uint128 supersededTimestamp; bool isValid }
+        function queryRoot(uint256 root) public view virtual returns (RootInfo memory)
+    ]"#,
+    event_derives(serde::Deserialize, serde::Serialize)
+);

--- a/e2e_tests/scenarios/tests/common/chain.rs
+++ b/e2e_tests/scenarios/tests/common/chain.rs
@@ -1,0 +1,66 @@
+use std::fs::File;
+use std::io::BufReader;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ethers::contract::{Contract, ContractFactory};
+use ethers::core::k256::ecdsa::SigningKey;
+use ethers::middleware::{Middleware, NonceManagerMiddleware, SignerMiddleware};
+use ethers::prelude::{Bytes, LocalWallet, Signer, U256};
+use ethers::providers::{Http, Provider};
+use ethers::signers::Wallet;
+use ethers::types::H160;
+use ethers::utils::{Anvil, AnvilInstance};
+use tracing::info;
+
+use super::abi as ContractAbi;
+use crate::common::prelude::instrument;
+
+type SpecialisedClient =
+    NonceManagerMiddleware<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>;
+type SharableClient = Arc<SpecialisedClient>;
+type SpecialisedFactory = ContractFactory<SpecialisedClient>;
+pub type SpecialisedContract = Contract<SpecialisedClient>;
+
+pub struct Chain {
+    pub private_key:      SigningKey,
+    pub identity_manager: SpecialisedContract,
+}
+
+#[instrument(skip_all)]
+pub async fn create_chain(chain_addr: String) -> anyhow::Result<Chain> {
+    // This private key is taken from tx-sitter configuration in compose.yaml.
+    // Env name: TX_SITTER__SERVICE__PREDEFINED__RELAYER__KEY_ID
+    let private_key = SigningKey::from_slice(&[
+        0xd1, 0x06, 0x07, 0x66, 0x2a, 0x85, 0x42, 0x4f, 0x02, 0xa3, 0x3f, 0xb1, 0xe6, 0xd0, 0x95,
+        0xbd, 0x0a, 0xc7, 0x15, 0x43, 0x96, 0xff, 0x09, 0x76, 0x2e, 0x41, 0xf8, 0x2f, 0xf2, 0x23,
+        0x3a, 0xaa,
+    ])?;
+    // This address is taken from signup-sequencer configuration in config.toml.
+    // Section: [network], param name: identity_manager_address
+    let identity_manager_contract_address =
+        H160::from_str("0x48483748eb0446A16cAE79141D0688e3F624Cb73")?;
+
+    let wallet = LocalWallet::from(private_key.clone()).with_chain_id(31337u64);
+
+    let provider = Provider::<Http>::try_from(format!("http://{}", chain_addr))
+        .expect("Failed to initialize chain endpoint")
+        .interval(Duration::from_millis(500u64));
+
+    // connect the wallet to the provider
+    let client = SignerMiddleware::new(provider, wallet.clone());
+    let client = NonceManagerMiddleware::new(client, wallet.address());
+    let client = Arc::new(client);
+
+    let identity_manager: SpecialisedContract = Contract::new(
+        identity_manager_contract_address,
+        ContractAbi::IDENTITYMANAGERCONTRACT_ABI.clone(),
+        client.clone(),
+    );
+
+    Ok(Chain {
+        private_key,
+        identity_manager,
+    })
+}

--- a/e2e_tests/scenarios/tests/common/docker_compose.rs
+++ b/e2e_tests/scenarios/tests/common/docker_compose.rs
@@ -34,6 +34,10 @@ impl<'a> DockerComposeGuard<'a> {
         format!("{}:{}", LOCAL_ADDR, self.signup_sequencer_balancer_port)
     }
 
+    pub fn get_chain_addr(&self) -> String {
+        format!("{}:{}", LOCAL_ADDR, self.chain_port)
+    }
+
     pub async fn restart_sequencer(&self) -> anyhow::Result<()> {
         let (stdout, stderr) = run_cmd_to_output(
             self.cwd,
@@ -96,6 +100,26 @@ impl<'a> DockerComposeGuard<'a> {
     fn update_balancer_port(&mut self, signup_sequencer_balancer_port: u32) {
         self.signup_sequencer_balancer_port = signup_sequencer_balancer_port
     }
+
+    fn update_chain_port(&mut self, chain_port: u32) {
+        self.chain_port = chain_port
+    }
+
+    fn get_mapped_port(&self, service_name: &str, port: u32) -> anyhow::Result<u32> {
+        let (stdout, stderr) = run_cmd_to_output(
+            self.cwd,
+            self.envs_with_ports(),
+            self.generate_command(format!("port {service_name} {port}").as_str()),
+        )
+        .context("Looking for balancer selected port.")?;
+
+        debug!(
+            "Docker compose starting output:\n stdout:\n{}\nstderr:\n{}\n",
+            stdout, stderr
+        );
+
+        Ok(parse_exposed_port(stdout))
+    }
 }
 
 impl<'a> Drop for DockerComposeGuard<'a> {
@@ -147,20 +171,11 @@ pub async fn setup(cwd: &str) -> anyhow::Result<DockerComposeGuard> {
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    let (stdout, stderr) = run_cmd_to_output(
-        res.cwd,
-        res.envs_with_ports(),
-        res.generate_command("port signup-sequencer-balancer 8080"),
-    )
-    .context("Looking for balancer selected port.")?;
-
-    debug!(
-        "Docker compose starting output:\n stdout:\n{}\nstderr:\n{}\n",
-        stdout, stderr
-    );
-
-    let balancer_port = parse_exposed_port(stdout);
+    let balancer_port = res.get_mapped_port("signup-sequencer-balancer", 8080)?;
     res.update_balancer_port(balancer_port);
+
+    let chain_port = res.get_mapped_port("chain", 8545)?;
+    res.update_chain_port(chain_port);
 
     await_running(&res).await?;
 

--- a/e2e_tests/scenarios/tests/common/mod.rs
+++ b/e2e_tests/scenarios/tests/common/mod.rs
@@ -147,7 +147,7 @@ pub async fn mined_inclusion_proof_with_retries(
         last_res = Some(inclusion_proof(client, uri, commitment).await?);
 
         if let Some(ref inclusion_proof_json) = last_res {
-            if let Some(root) = inclusion_proof_json.root {
+            if let Some(root) = inclusion_proof_json.0.root {
                 let (root, ..) = chain
                     .identity_manager
                     .query_root(root.into())

--- a/e2e_tests/scenarios/tests/insert_100.rs
+++ b/e2e_tests/scenarios/tests/insert_100.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::prelude::*;
 
-use crate::common::docker_compose;
+use crate::common::{chain, docker_compose};
 
 #[tokio::test]
 async fn insert_100() -> anyhow::Result<()> {
@@ -11,6 +11,7 @@ async fn insert_100() -> anyhow::Result<()> {
     info!("Starting e2e test");
 
     let docker_compose = docker_compose::setup("./../docker-compose").await?;
+    let chain = chain::create_chain(docker_compose.get_chain_addr()).await?;
 
     let uri = format!("http://{}", docker_compose.get_local_addr());
     let client = Client::new();
@@ -22,7 +23,7 @@ async fn insert_100() -> anyhow::Result<()> {
     }
 
     for commitment in identities.iter() {
-        mined_inclusion_proof_with_retries(&client, &uri, commitment, 60, 10.0).await?;
+        mined_inclusion_proof_with_retries(&client, &uri, &chain, commitment, 60, 10.0).await?;
     }
 
     Ok(())

--- a/e2e_tests/scenarios/tests/insert_delete_insert.rs
+++ b/e2e_tests/scenarios/tests/insert_delete_insert.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::prelude::*;
 
-use crate::common::docker_compose;
+use crate::common::{chain, docker_compose};
 
 #[tokio::test]
 async fn insert_delete_insert() -> anyhow::Result<()> {
@@ -11,6 +11,7 @@ async fn insert_delete_insert() -> anyhow::Result<()> {
     info!("Starting e2e test");
 
     let docker_compose = docker_compose::setup("./../docker-compose").await?;
+    let chain = chain::create_chain(docker_compose.get_chain_addr()).await?;
 
     let uri = format!("http://{}", docker_compose.get_local_addr());
     let client = Client::new();
@@ -22,7 +23,7 @@ async fn insert_delete_insert() -> anyhow::Result<()> {
     }
 
     for commitment in identities.iter() {
-        mined_inclusion_proof_with_retries(&client, &uri, commitment, 60, 10.0).await?;
+        mined_inclusion_proof_with_retries(&client, &uri, &chain, commitment, 60, 10.0).await?;
     }
 
     let first_commitment = identities.first().unwrap();
@@ -37,7 +38,7 @@ async fn insert_delete_insert() -> anyhow::Result<()> {
     }
 
     for commitment in new_identities.iter() {
-        mined_inclusion_proof_with_retries(&client, &uri, commitment, 60, 10.0).await?;
+        mined_inclusion_proof_with_retries(&client, &uri, &chain, commitment, 60, 10.0).await?;
     }
 
     Ok(())

--- a/e2e_tests/scenarios/tests/insert_restart_insert.rs
+++ b/e2e_tests/scenarios/tests/insert_restart_insert.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::prelude::*;
 
-use crate::common::docker_compose;
+use crate::common::{chain, docker_compose};
 
 #[tokio::test]
 async fn insert_restart_insert() -> anyhow::Result<()> {
@@ -11,6 +11,7 @@ async fn insert_restart_insert() -> anyhow::Result<()> {
     info!("Starting e2e test");
 
     let docker_compose = docker_compose::setup("./../docker-compose").await?;
+    let chain = chain::create_chain(docker_compose.get_chain_addr()).await?;
 
     let uri = format!("http://{}", docker_compose.get_local_addr());
     let client = Client::new();
@@ -22,7 +23,7 @@ async fn insert_restart_insert() -> anyhow::Result<()> {
     }
 
     for commitment in identities.iter() {
-        mined_inclusion_proof_with_retries(&client, &uri, commitment, 60, 10.0).await?;
+        mined_inclusion_proof_with_retries(&client, &uri, &chain, commitment, 60, 10.0).await?;
     }
 
     docker_compose.restart_sequencer().await?;
@@ -34,7 +35,7 @@ async fn insert_restart_insert() -> anyhow::Result<()> {
     }
 
     for commitment in identities.iter() {
-        mined_inclusion_proof_with_retries(&client, &uri, commitment, 60, 10.0).await?;
+        mined_inclusion_proof_with_retries(&client, &uri, &chain, commitment, 60, 10.0).await?;
     }
 
     Ok(())

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -261,10 +261,10 @@ mod test {
         assert_eq!(commit_hash, hash);
 
         let commit = db
-            .get_unprocessed_commit_status(&commit_hash)
-            .await?
+            .get_unprocessed_error(&commit_hash)
+            .await
             .expect("expected commitment status");
-        assert_eq!(commit.0, UnprocessedStatus::New);
+        assert_eq!(commit, Some("".to_string()));
 
         let identity_count = db
             .get_eligible_unprocessed_commitments(UnprocessedStatus::New)

--- a/src/database/query.rs
+++ b/src/database/query.rs
@@ -141,24 +141,6 @@ pub trait DatabaseQuery<'a>: Executor<'a, Database = Postgres> {
         .await?)
     }
 
-    async fn get_commitments_by_statuses(
-        self,
-        statuses: Vec<ProcessedStatus>,
-    ) -> Result<Vec<TreeUpdate>, Error> {
-        let statuses: Vec<&str> = statuses.into_iter().map(<&str>::from).collect();
-        Ok(sqlx::query_as::<_, TreeUpdate>(
-            r#"
-            SELECT leaf_index, commitment as element
-            FROM identities
-            WHERE status = ANY($1)
-            ORDER BY id ASC;
-            "#,
-        )
-        .bind(&statuses[..]) // Official workaround https://github.com/launchbadge/sqlx/blob/main/FAQ.md#how-can-i-do-a-select--where-foo-in--query
-        .fetch_all(self)
-        .await?)
-    }
-
     async fn get_non_zero_commitments_by_leaf_indexes<I: IntoIterator<Item = usize>>(
         self,
         leaf_indexes: I,

--- a/src/identity/processor.rs
+++ b/src/identity/processor.rs
@@ -20,7 +20,7 @@ use crate::database::query::DatabaseQuery;
 use crate::database::types::{BatchEntry, BatchType};
 use crate::database::{Database, Error};
 use crate::ethereum::{Ethereum, ReadProvider};
-use crate::identity_tree::Hash;
+use crate::identity_tree::{Canonical, Hash, Intermediate, TreeVersion, TreeWithNextVersion};
 use crate::prover::identity::Identity;
 use crate::prover::repository::ProverRepository;
 use crate::prover::Prover;
@@ -33,7 +33,11 @@ pub type TransactionId = String;
 pub trait IdentityProcessor: Send + Sync + 'static {
     async fn commit_identities(&self, batch: &BatchEntry) -> anyhow::Result<TransactionId>;
 
-    async fn finalize_identities(&self) -> anyhow::Result<()>;
+    async fn finalize_identities(
+        &self,
+        processed_tree: &TreeVersion<Intermediate>,
+        mined_tree: &TreeVersion<Canonical>,
+    ) -> anyhow::Result<()>;
 
     async fn await_clean_slate(&self) -> anyhow::Result<()>;
 
@@ -86,16 +90,24 @@ impl IdentityProcessor for OnChainIdentityProcessor {
         }
     }
 
-    async fn finalize_identities(&self) -> anyhow::Result<()> {
+    async fn finalize_identities(
+        &self,
+        processed_tree: &TreeVersion<Intermediate>,
+        mined_tree: &TreeVersion<Canonical>,
+    ) -> anyhow::Result<()> {
         let mainnet_logs = self.fetch_mainnet_logs().await?;
 
-        self.finalize_mainnet_roots(&mainnet_logs, self.config.app.max_epoch_duration)
-            .await?;
+        self.finalize_mainnet_roots(
+            processed_tree,
+            &mainnet_logs,
+            self.config.app.max_epoch_duration,
+        )
+        .await?;
 
         let mut roots = Self::extract_roots_from_mainnet_logs(mainnet_logs);
         roots.extend(self.fetch_secondary_logs().await?);
 
-        self.finalize_secondary_roots(roots).await?;
+        self.finalize_secondary_roots(mined_tree, roots).await?;
 
         Ok(())
     }
@@ -390,6 +402,7 @@ impl OnChainIdentityProcessor {
     #[instrument(level = "info", skip_all)]
     async fn finalize_mainnet_roots(
         &self,
+        processed_tree: &TreeVersion<Intermediate>,
         logs: &[Log],
         max_epoch_duration: Duration,
     ) -> Result<(), anyhow::Error> {
@@ -422,13 +435,21 @@ impl OnChainIdentityProcessor {
                 self.update_eligible_recoveries(log, max_epoch_duration)
                     .await?;
             }
+
+            let updates_count = processed_tree.apply_updates_up_to(post_root.into());
+
+            info!(updates_count, ?pre_root, ?post_root, "Mined tree updated");
         }
 
         Ok(())
     }
 
     #[instrument(level = "info", skip_all)]
-    async fn finalize_secondary_roots(&self, roots: Vec<U256>) -> Result<(), anyhow::Error> {
+    async fn finalize_secondary_roots(
+        &self,
+        finalized_tree: &TreeVersion<Canonical>,
+        roots: Vec<U256>,
+    ) -> Result<(), anyhow::Error> {
         for root in roots {
             info!(?root, "Finalizing root");
 
@@ -442,6 +463,7 @@ impl OnChainIdentityProcessor {
             }
 
             self.database.mark_root_as_mined_tx(&root.into()).await?;
+            finalized_tree.apply_updates_up_to(root.into());
 
             info!(?root, "Root finalized");
         }
@@ -544,7 +566,11 @@ impl IdentityProcessor for OffChainIdentityProcessor {
         Ok(batch.id.to_string())
     }
 
-    async fn finalize_identities(&self) -> anyhow::Result<()> {
+    async fn finalize_identities(
+        &self,
+        processed_tree: &TreeVersion<Intermediate>,
+        mined_tree: &TreeVersion<Canonical>,
+    ) -> anyhow::Result<()> {
         let batches = {
             let mut committed_batches = self.committed_batches.lock().unwrap();
             let copied = committed_batches.clone();
@@ -565,6 +591,8 @@ impl IdentityProcessor for OffChainIdentityProcessor {
             self.database
                 .mark_root_as_mined_tx(&batch.next_root)
                 .await?;
+            processed_tree.apply_updates_up_to(batch.next_root);
+            mined_tree.apply_updates_up_to(batch.next_root);
         }
 
         Ok(())

--- a/src/identity/processor.rs
+++ b/src/identity/processor.rs
@@ -20,7 +20,7 @@ use crate::database::query::DatabaseQuery;
 use crate::database::types::{BatchEntry, BatchType};
 use crate::database::{Database, Error};
 use crate::ethereum::{Ethereum, ReadProvider};
-use crate::identity_tree::{Canonical, Hash, Intermediate, TreeVersion, TreeWithNextVersion};
+use crate::identity_tree::{Canonical, Hash, TreeVersion, TreeWithNextVersion};
 use crate::prover::identity::Identity;
 use crate::prover::repository::ProverRepository;
 use crate::prover::Prover;
@@ -35,8 +35,6 @@ pub trait IdentityProcessor: Send + Sync + 'static {
 
     async fn finalize_identities(
         &self,
-        processed_tree: &TreeVersion<Intermediate>,
-        mined_tree: &TreeVersion<Canonical>,
     ) -> anyhow::Result<()>;
 
     async fn await_clean_slate(&self) -> anyhow::Result<()>;
@@ -92,13 +90,10 @@ impl IdentityProcessor for OnChainIdentityProcessor {
 
     async fn finalize_identities(
         &self,
-        processed_tree: &TreeVersion<Intermediate>,
-        mined_tree: &TreeVersion<Canonical>,
     ) -> anyhow::Result<()> {
         let mainnet_logs = self.fetch_mainnet_logs().await?;
 
         self.finalize_mainnet_roots(
-            processed_tree,
             &mainnet_logs,
             self.config.app.max_epoch_duration,
         )
@@ -107,7 +102,7 @@ impl IdentityProcessor for OnChainIdentityProcessor {
         let mut roots = Self::extract_roots_from_mainnet_logs(mainnet_logs);
         roots.extend(self.fetch_secondary_logs().await?);
 
-        self.finalize_secondary_roots(mined_tree, roots).await?;
+        self.finalize_secondary_roots(roots).await?;
 
         Ok(())
     }
@@ -402,7 +397,6 @@ impl OnChainIdentityProcessor {
     #[instrument(level = "info", skip_all)]
     async fn finalize_mainnet_roots(
         &self,
-        processed_tree: &TreeVersion<Intermediate>,
         logs: &[Log],
         max_epoch_duration: Duration,
     ) -> Result<(), anyhow::Error> {
@@ -435,21 +429,13 @@ impl OnChainIdentityProcessor {
                 self.update_eligible_recoveries(log, max_epoch_duration)
                     .await?;
             }
-
-            let updates_count = processed_tree.apply_updates_up_to(post_root.into());
-
-            info!(updates_count, ?pre_root, ?post_root, "Mined tree updated");
         }
 
         Ok(())
     }
 
     #[instrument(level = "info", skip_all)]
-    async fn finalize_secondary_roots(
-        &self,
-        finalized_tree: &TreeVersion<Canonical>,
-        roots: Vec<U256>,
-    ) -> Result<(), anyhow::Error> {
+    async fn finalize_secondary_roots(&self, roots: Vec<U256>) -> Result<(), anyhow::Error> {
         for root in roots {
             info!(?root, "Finalizing root");
 
@@ -463,7 +449,6 @@ impl OnChainIdentityProcessor {
             }
 
             self.database.mark_root_as_mined_tx(&root.into()).await?;
-            finalized_tree.apply_updates_up_to(root.into());
 
             info!(?root, "Root finalized");
         }
@@ -570,8 +555,6 @@ impl IdentityProcessor for OffChainIdentityProcessor {
 
     async fn finalize_identities(
         &self,
-        processed_tree: &TreeVersion<Intermediate>,
-        mined_tree: &TreeVersion<Canonical>,
     ) -> anyhow::Result<()> {
         let batches = {
             let mut committed_batches = self.committed_batches.lock().unwrap();
@@ -593,8 +576,6 @@ impl IdentityProcessor for OffChainIdentityProcessor {
             self.database
                 .mark_root_as_mined_tx(&batch.next_root)
                 .await?;
-            processed_tree.apply_updates_up_to(batch.next_root);
-            mined_tree.apply_updates_up_to(batch.next_root);
         }
 
         Ok(())

--- a/src/identity/processor.rs
+++ b/src/identity/processor.rs
@@ -495,13 +495,11 @@ impl OnChainIdentityProcessor {
                 .await
                 .context("Could not fetch deletion indices from tx")?;
 
-            info!("[zzz] 1: {:?}", commitments);
             let commitments = self
                 .database
                 .get_non_zero_commitments_by_leaf_indexes(commitments.iter().copied())
                 .await?;
             let commitments: Vec<U256> = commitments.into_iter().map(Into::into).collect();
-            info!("[zzz] 2: {:?}", commitments);
 
             // Fetch the root history expiry time on chain
             let root_history_expiry = self.identity_manager.root_history_expiry().await?;

--- a/src/identity_tree/initializer.rs
+++ b/src/identity_tree/initializer.rs
@@ -69,19 +69,19 @@ impl TreeInitializer {
         &self,
         initial_root_hash: Hash,
     ) -> anyhow::Result<TreeState> {
-        let mut mined_items = self
+        let mut mined_or_processed_items = self
             .database
-            .get_commitments_by_status(ProcessedStatus::Mined)
+            .get_commitments_by_statuses(vec![ProcessedStatus::Mined, ProcessedStatus::Processed])
             .await?;
 
-        mined_items.sort_by_key(|item| item.leaf_index);
+        mined_or_processed_items.sort_by_key(|item| item.leaf_index);
 
-        let mined_items = dedup_tree_updates(mined_items);
+        let mined_or_processed_items = dedup_tree_updates(mined_or_processed_items);
 
         if !self.config.force_cache_purge {
             info!("Attempting to restore tree from cache");
             if let Some(tree_state) = self
-                .get_cached_tree_state(&mined_items, initial_root_hash)
+                .get_cached_tree_state(&mined_or_processed_items, initial_root_hash)
                 .await?
             {
                 info!("tree restored from cache");
@@ -90,7 +90,7 @@ impl TreeInitializer {
         }
 
         info!("Initializing tree from the database");
-        let tree_state = self.initialize_tree(mined_items).await?;
+        let tree_state = self.initialize_tree(mined_or_processed_items).await?;
 
         info!("tree initialization successful");
 
@@ -131,21 +131,21 @@ impl TreeInitializer {
 
     async fn get_cached_tree_state(
         &self,
-        mined_items: &[TreeUpdate],
+        mined_or_processed_items: &[TreeUpdate],
         initial_root_hash: Hash,
     ) -> anyhow::Result<Option<TreeState>> {
-        let mut last_mined_index_in_dense: Option<usize> = None;
+        let mut last_mined_or_processed_index_in_dense: Option<usize> = None;
         let leftover_items = Self::get_leftover_leaves_and_update_index(
-            &mut last_mined_index_in_dense,
+            &mut last_mined_or_processed_index_in_dense,
             self.config.dense_tree_prefix_depth,
-            mined_items,
+            mined_or_processed_items,
         );
 
-        let Some(mined_builder) = CanonicalTreeBuilder::restore(
+        let Some(processed_builder) = CanonicalTreeBuilder::restore(
             self.config.tree_depth,
             self.config.dense_tree_prefix_depth,
             &self.config.initial_leaf_value,
-            last_mined_index_in_dense,
+            last_mined_or_processed_index_in_dense,
             &leftover_items,
             self.config.tree_gc_threshold,
             &self.config.cache_file,
@@ -153,35 +153,25 @@ impl TreeInitializer {
             return Ok(None);
         };
 
-        let (mined, mut processed_builder) = mined_builder.seal();
+        let (processed, batching_builder) = processed_builder.seal();
 
         match self
             .database
-            .get_latest_root_by_status(ProcessedStatus::Mined)
+            .get_latest_root_by_status(ProcessedStatus::Processed)
             .await?
         {
             Some(root) => {
-                if !mined.get_root().eq(&root) {
+                if !processed.get_root().eq(&root) {
                     return Ok(None);
                 }
             }
             None => {
-                if !mined.get_root().eq(&initial_root_hash) {
+                if !processed.get_root().eq(&initial_root_hash) {
                     return Ok(None);
                 }
             }
         }
 
-        let processed_items = self
-            .database
-            .get_commitments_by_status(ProcessedStatus::Processed)
-            .await?;
-
-        for processed_item in processed_items {
-            processed_builder.update(&processed_item);
-        }
-
-        let (processed, batching_builder) = processed_builder.seal_and_continue();
         let (batching, mut latest_builder) = batching_builder.seal_and_continue();
 
         let pending_items = self
@@ -201,20 +191,26 @@ impl TreeInitializer {
             assert_eq!(batching.get_root(), batch.next_root);
         }
 
-        Ok(Some(TreeState::new(mined, processed, batching, latest)))
+        Ok(Some(TreeState::new(processed, batching, latest)))
     }
 
     #[instrument(skip_all)]
-    async fn initialize_tree(&self, mined_items: Vec<TreeUpdate>) -> anyhow::Result<TreeState> {
+    async fn initialize_tree(
+        &self,
+        mined_or_processed_items: Vec<TreeUpdate>,
+    ) -> anyhow::Result<TreeState> {
         let initial_leaf_value = self.config.initial_leaf_value;
 
-        let initial_leaves = if mined_items.is_empty() {
+        let initial_leaves = if mined_or_processed_items.is_empty() {
             vec![]
         } else {
-            let max_leaf = mined_items.last().map(|item| item.leaf_index).unwrap();
+            let max_leaf = mined_or_processed_items
+                .last()
+                .map(|item| item.leaf_index)
+                .unwrap();
             let mut leaves = vec![initial_leaf_value; max_leaf + 1];
 
-            for item in mined_items {
+            for item in mined_or_processed_items {
                 leaves[item.leaf_index] = item.element;
             }
 
@@ -227,7 +223,7 @@ impl TreeInitializer {
         let tree_gc_threshold = self.config.tree_gc_threshold;
         let cache_file = self.config.cache_file.clone();
 
-        let mined_builder = tokio::task::spawn_blocking(move || {
+        let processed_builder = tokio::task::spawn_blocking(move || {
             CanonicalTreeBuilder::new(
                 tree_depth,
                 dense_tree_prefix_depth,
@@ -239,24 +235,7 @@ impl TreeInitializer {
         })
         .await?;
 
-        let (mined, mut processed_builder) = mined_builder.seal();
-
-        let processed_items = self
-            .database
-            .get_commitments_by_status(ProcessedStatus::Processed)
-            .await?;
-
-        info!("Updating processed tree");
-        let processed_builder = tokio::task::spawn_blocking(move || {
-            for processed_item in processed_items {
-                processed_builder.update(&processed_item);
-            }
-
-            processed_builder
-        })
-        .await?;
-
-        let (processed, batching_builder) = processed_builder.seal_and_continue();
+        let (processed, batching_builder) = processed_builder.seal();
         let (batching, mut latest_builder) = batching_builder.seal_and_continue();
 
         let pending_items = self
@@ -284,7 +263,7 @@ impl TreeInitializer {
             assert_eq!(batching.get_root(), batch.next_root);
         }
 
-        Ok(TreeState::new(mined, processed, batching, latest))
+        Ok(TreeState::new(processed, batching, latest))
     }
 }
 

--- a/src/identity_tree/initializer.rs
+++ b/src/identity_tree/initializer.rs
@@ -50,7 +50,7 @@ impl TreeInitializer {
         let mut tree_state = self.restore_or_initialize_tree(initial_root_hash).await?;
         info!("Tree state initialization took: {:?}", timer.elapsed());
 
-        let tree_root = tree_state.get_processed_tree().get_root();
+        let tree_root = tree_state.get_batching_tree().get_root();
 
         if tree_root != initial_root_hash {
             warn!(
@@ -69,19 +69,19 @@ impl TreeInitializer {
         &self,
         initial_root_hash: Hash,
     ) -> anyhow::Result<TreeState> {
-        let mut mined_items = self
+        let mut mined_or_processed_items = self
             .database
-            .get_commitments_by_status(ProcessedStatus::Mined)
+            .get_commitments_by_statuses(vec![ProcessedStatus::Mined, ProcessedStatus::Processed])
             .await?;
 
-        mined_items.sort_by_key(|item| item.leaf_index);
+        mined_or_processed_items.sort_by_key(|item| item.leaf_index);
 
-        let mined_items = dedup_tree_updates(mined_items);
+        let mined_or_processed_items = dedup_tree_updates(mined_or_processed_items);
 
         if !self.config.force_cache_purge {
             info!("Attempting to restore tree from cache");
             if let Some(tree_state) = self
-                .get_cached_tree_state(&mined_items, initial_root_hash)
+                .get_cached_tree_state(&mined_or_processed_items, initial_root_hash)
                 .await?
             {
                 info!("tree restored from cache");
@@ -90,7 +90,7 @@ impl TreeInitializer {
         }
 
         info!("Initializing tree from the database");
-        let tree_state = self.initialize_tree(mined_items).await?;
+        let tree_state = self.initialize_tree(mined_or_processed_items).await?;
 
         info!("tree initialization successful");
 
@@ -100,12 +100,15 @@ impl TreeInitializer {
     pub fn get_leftover_leaves_and_update_index(
         index: &mut Option<usize>,
         dense_prefix_depth: usize,
-        mined_items: &[TreeUpdate],
+        mined_or_processed_items: &[TreeUpdate],
     ) -> Vec<ruint::Uint<256, 4>> {
-        let leftover_items = if mined_items.is_empty() {
+        let leftover_items = if mined_or_processed_items.is_empty() {
             vec![]
         } else {
-            let max_leaf = mined_items.last().map(|item| item.leaf_index).unwrap();
+            let max_leaf = mined_or_processed_items
+                .last()
+                .map(|item| item.leaf_index)
+                .unwrap();
             // if the last index is greater then dense_prefix_depth, 1 << dense_prefix_depth
             // should be the last index in restored tree
             let last_index = std::cmp::min(max_leaf, (1 << dense_prefix_depth) - 1);
@@ -117,7 +120,7 @@ impl TreeInitializer {
 
             let mut leaves = Vec::with_capacity(max_leaf - last_index);
 
-            let leftover = &mined_items[(last_index + 1)..];
+            let leftover = &mined_or_processed_items[(last_index + 1)..];
 
             for item in leftover {
                 leaves.push(item.element);
@@ -131,17 +134,17 @@ impl TreeInitializer {
 
     async fn get_cached_tree_state(
         &self,
-        mined_items: &[TreeUpdate],
+        mined_or_processed_items: &[TreeUpdate],
         initial_root_hash: Hash,
     ) -> anyhow::Result<Option<TreeState>> {
         let mut last_mined_index_in_dense: Option<usize> = None;
         let leftover_items = Self::get_leftover_leaves_and_update_index(
             &mut last_mined_index_in_dense,
             self.config.dense_tree_prefix_depth,
-            mined_items,
+            mined_or_processed_items,
         );
 
-        let Some(mined_builder) = CanonicalTreeBuilder::restore(
+        let Some(batching_builder) = CanonicalTreeBuilder::restore(
             self.config.tree_depth,
             self.config.dense_tree_prefix_depth,
             &self.config.initial_leaf_value,
@@ -153,7 +156,7 @@ impl TreeInitializer {
             return Ok(None);
         };
 
-        let (mined, mut processed_builder) = mined_builder.seal();
+        let (batching, mut latest_builder) = batching_builder.seal();
 
         match self
             .database
@@ -161,28 +164,16 @@ impl TreeInitializer {
             .await?
         {
             Some(root) => {
-                if !mined.get_root().eq(&root) {
+                if !batching.get_root().eq(&root) {
                     return Ok(None);
                 }
             }
             None => {
-                if !mined.get_root().eq(&initial_root_hash) {
+                if !batching.get_root().eq(&initial_root_hash) {
                     return Ok(None);
                 }
             }
         }
-
-        let processed_items = self
-            .database
-            .get_commitments_by_status(ProcessedStatus::Processed)
-            .await?;
-
-        for processed_item in processed_items {
-            processed_builder.update(&processed_item);
-        }
-
-        let (processed, batching_builder) = processed_builder.seal_and_continue();
-        let (batching, mut latest_builder) = batching_builder.seal_and_continue();
 
         let pending_items = self
             .database
@@ -201,20 +192,26 @@ impl TreeInitializer {
             assert_eq!(batching.get_root(), batch.next_root);
         }
 
-        Ok(Some(TreeState::new(mined, processed, batching, latest)))
+        Ok(Some(TreeState::new(batching, latest)))
     }
 
     #[instrument(skip_all)]
-    async fn initialize_tree(&self, mined_items: Vec<TreeUpdate>) -> anyhow::Result<TreeState> {
+    async fn initialize_tree(
+        &self,
+        mined_or_processed_items: Vec<TreeUpdate>,
+    ) -> anyhow::Result<TreeState> {
         let initial_leaf_value = self.config.initial_leaf_value;
 
-        let initial_leaves = if mined_items.is_empty() {
+        let initial_leaves = if mined_or_processed_items.is_empty() {
             vec![]
         } else {
-            let max_leaf = mined_items.last().map(|item| item.leaf_index).unwrap();
+            let max_leaf = mined_or_processed_items
+                .last()
+                .map(|item| item.leaf_index)
+                .unwrap();
             let mut leaves = vec![initial_leaf_value; max_leaf + 1];
 
-            for item in mined_items {
+            for item in mined_or_processed_items {
                 leaves[item.leaf_index] = item.element;
             }
 
@@ -227,7 +224,7 @@ impl TreeInitializer {
         let tree_gc_threshold = self.config.tree_gc_threshold;
         let cache_file = self.config.cache_file.clone();
 
-        let mined_builder = tokio::task::spawn_blocking(move || {
+        let batching_builder = tokio::task::spawn_blocking(move || {
             CanonicalTreeBuilder::new(
                 tree_depth,
                 dense_tree_prefix_depth,
@@ -239,25 +236,7 @@ impl TreeInitializer {
         })
         .await?;
 
-        let (mined, mut processed_builder) = mined_builder.seal();
-
-        let processed_items = self
-            .database
-            .get_commitments_by_status(ProcessedStatus::Processed)
-            .await?;
-
-        info!("Updating processed tree");
-        let processed_builder = tokio::task::spawn_blocking(move || {
-            for processed_item in processed_items {
-                processed_builder.update(&processed_item);
-            }
-
-            processed_builder
-        })
-        .await?;
-
-        let (processed, batching_builder) = processed_builder.seal_and_continue();
-        let (batching, mut latest_builder) = batching_builder.seal_and_continue();
+        let (batching, mut latest_builder) = batching_builder.seal();
 
         let pending_items = self
             .database
@@ -284,7 +263,7 @@ impl TreeInitializer {
             assert_eq!(batching.get_root(), batch.next_root);
         }
 
-        Ok(TreeState::new(mined, processed, batching, latest))
+        Ok(TreeState::new(batching, latest))
     }
 }
 

--- a/src/identity_tree/mod.rs
+++ b/src/identity_tree/mod.rs
@@ -500,8 +500,7 @@ where
 
 #[derive(Clone)]
 pub struct TreeState {
-    mined:     TreeVersion<Canonical>,
-    processed: TreeVersion<Intermediate>,
+    processed: TreeVersion<Canonical>,
     batching:  TreeVersion<Intermediate>,
     latest:    TreeVersion<Latest>,
 }
@@ -509,13 +508,11 @@ pub struct TreeState {
 impl TreeState {
     #[must_use]
     pub const fn new(
-        mined: TreeVersion<Canonical>,
-        processed: TreeVersion<Intermediate>,
+        processed: TreeVersion<Canonical>,
         batching: TreeVersion<Intermediate>,
         latest: TreeVersion<Latest>,
     ) -> Self {
         Self {
-            mined,
             processed,
             batching,
             latest,
@@ -532,20 +529,11 @@ impl TreeState {
     }
 
     #[must_use]
-    pub fn get_mined_tree(&self) -> TreeVersion<Canonical> {
-        self.mined.clone()
-    }
-
-    pub fn mined_tree(&self) -> &TreeVersion<Canonical> {
-        &self.mined
-    }
-
-    #[must_use]
-    pub fn get_processed_tree(&self) -> TreeVersion<Intermediate> {
+    pub fn get_processed_tree(&self) -> TreeVersion<Canonical> {
         self.processed.clone()
     }
 
-    pub fn processed_tree(&self) -> &TreeVersion<Intermediate> {
+    pub fn processed_tree(&self) -> &TreeVersion<Canonical> {
         &self.processed
     }
 

--- a/src/identity_tree/mod.rs
+++ b/src/identity_tree/mod.rs
@@ -319,6 +319,15 @@ impl Version for Canonical {
 }
 impl HasNextVersion for Canonical {}
 
+/// Marker for an intermediate version – one that has both a predecessor and a
+/// successor.
+#[derive(Clone)]
+pub struct Intermediate;
+impl Version for Intermediate {
+    type TreeVersion = lazy_merkle_tree::Derived;
+}
+impl HasNextVersion for Intermediate {}
+
 /// Marker for the latest tree version – one that has no successor. It enables a
 /// different API, focusing on outside updates, rather than just pulling in
 /// updates from the successor.
@@ -491,14 +500,26 @@ where
 
 #[derive(Clone)]
 pub struct TreeState {
-    batching: TreeVersion<Canonical>,
-    latest:   TreeVersion<Latest>,
+    mined:     TreeVersion<Canonical>,
+    processed: TreeVersion<Intermediate>,
+    batching:  TreeVersion<Intermediate>,
+    latest:    TreeVersion<Latest>,
 }
 
 impl TreeState {
     #[must_use]
-    pub const fn new(batching: TreeVersion<Canonical>, latest: TreeVersion<Latest>) -> Self {
-        Self { batching, latest }
+    pub const fn new(
+        mined: TreeVersion<Canonical>,
+        processed: TreeVersion<Intermediate>,
+        batching: TreeVersion<Intermediate>,
+        latest: TreeVersion<Latest>,
+    ) -> Self {
+        Self {
+            mined,
+            processed,
+            batching,
+            latest,
+        }
     }
 
     pub fn latest_tree(&self) -> &TreeVersion<Latest> {
@@ -511,11 +532,29 @@ impl TreeState {
     }
 
     #[must_use]
-    pub fn get_batching_tree(&self) -> TreeVersion<Canonical> {
+    pub fn get_mined_tree(&self) -> TreeVersion<Canonical> {
+        self.mined.clone()
+    }
+
+    pub fn mined_tree(&self) -> &TreeVersion<Canonical> {
+        &self.mined
+    }
+
+    #[must_use]
+    pub fn get_processed_tree(&self) -> TreeVersion<Intermediate> {
+        self.processed.clone()
+    }
+
+    pub fn processed_tree(&self) -> &TreeVersion<Intermediate> {
+        &self.processed
+    }
+
+    #[must_use]
+    pub fn get_batching_tree(&self) -> TreeVersion<Intermediate> {
         self.batching.clone()
     }
 
-    pub fn batching_tree(&self) -> &TreeVersion<Canonical> {
+    pub fn batching_tree(&self) -> &TreeVersion<Intermediate> {
         &self.batching
     }
 
@@ -660,7 +699,7 @@ pub struct DerivedTreeBuilder<P: Version> {
 impl<P: Version> DerivedTreeBuilder<P> {
     #[must_use]
     const fn new<Prev: Version>(
-        tree: PoseidonTree<Derived>,
+        tree: PoseidonTree<lazy_merkle_tree::Derived>,
         next_leaf: usize,
         prev: TreeVersion<Prev>,
     ) -> DerivedTreeBuilder<Prev> {
@@ -679,6 +718,19 @@ impl<P: Version> DerivedTreeBuilder<P> {
     /// Updates a leaf in the resulting tree.
     pub fn update(&mut self, update: &TreeUpdate) {
         self.current.update(update.leaf_index, update.element);
+    }
+
+    /// Seals this version and returns a builder for the next version.
+    #[must_use]
+    pub fn seal_and_continue(
+        self,
+    ) -> (TreeVersion<Intermediate>, DerivedTreeBuilder<Intermediate>) {
+        let next_tree = self.current.tree.clone();
+        let next_leaf = self.current.next_leaf;
+        let sealed = TreeVersion(Arc::new(Mutex::new(self.current)));
+        let next = Self::new(next_tree, next_leaf, sealed.clone());
+        self.prev.get_data().next = Some(sealed.as_derived());
+        (sealed, next)
     }
 
     /// Seals this version and finishes the building process.

--- a/src/identity_tree/mod.rs
+++ b/src/identity_tree/mod.rs
@@ -54,7 +54,6 @@ pub struct RootItem {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct InclusionProof {
-    pub status:  Status,
     pub root:    Option<Field>,
     pub proof:   Option<Proof>,
     pub message: Option<String>,
@@ -561,14 +560,9 @@ impl TreeState {
 
     #[must_use]
     pub fn get_proof_for(&self, item: &TreeItem) -> (Field, InclusionProof) {
-        let (leaf, root, proof) = match item.status {
-            ProcessedStatus::Pending => self.latest.get_leaf_and_proof(item.leaf_index),
-            ProcessedStatus::Processed => self.processed.get_leaf_and_proof(item.leaf_index),
-            ProcessedStatus::Mined => self.mined.get_leaf_and_proof(item.leaf_index),
-        };
+        let (leaf, root, proof) = self.latest.get_leaf_and_proof(item.leaf_index);
 
         let proof = InclusionProof {
-            status:  item.status.into(),
             root:    Some(root),
             proof:   Some(proof),
             message: None,

--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -1,4 +1,3 @@
-use chrono::Utc;
 use hyper::StatusCode;
 use semaphore::protocol::Proof;
 use semaphore::Field;
@@ -8,28 +7,13 @@ use crate::identity_tree::{Hash, InclusionProof, RootItem};
 use crate::prover::{ProverConfig, ProverType};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
-pub struct InclusionProofResponse {
-    pub root:    Option<Field>,
-    pub proof:   Option<semaphore::poseidon_tree::Proof>,
-    pub message: Option<String>,
-}
+pub struct InclusionProofResponse(pub InclusionProof);
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ListBatchSizesResponse(pub Vec<ListBatchSizesResponseEntry>);
+pub struct ListBatchSizesResponse(pub Vec<ProverConfig>);
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ListBatchSizesResponseEntry {
-    pub url:         String,
-    pub timeout_s:   u64,
-    pub batch_size:  usize,
-    pub prover_type: ProverType,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct VerifySemaphoreProofResponse {
-    pub root:                Field,
-    pub pending_valid_as_of: chrono::DateTime<Utc>,
-}
+pub struct VerifySemaphoreProofResponse(pub RootItem);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -108,11 +92,7 @@ pub struct RecoveryRequest {
 
 impl From<InclusionProof> for InclusionProofResponse {
     fn from(value: InclusionProof) -> Self {
-        Self {
-            root:    value.root,
-            proof:   value.proof,
-            message: value.message,
-        }
+        Self(value)
     }
 }
 
@@ -124,17 +104,7 @@ impl ToResponseCode for InclusionProofResponse {
 
 impl From<Vec<ProverConfig>> for ListBatchSizesResponse {
     fn from(value: Vec<ProverConfig>) -> Self {
-        Self(
-            value
-                .into_iter()
-                .map(|v| ListBatchSizesResponseEntry {
-                    url:         v.url,
-                    timeout_s:   v.timeout_s,
-                    batch_size:  v.batch_size,
-                    prover_type: v.prover_type,
-                })
-                .collect(),
-        )
+        Self(value)
     }
 }
 
@@ -146,10 +116,7 @@ impl ToResponseCode for ListBatchSizesResponse {
 
 impl From<RootItem> for VerifySemaphoreProofResponse {
     fn from(value: RootItem) -> Self {
-        Self {
-            root:                value.root,
-            pending_valid_as_of: value.pending_valid_as_of,
-        }
+        Self(value)
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -36,8 +36,6 @@ async fn inclusion_proof(
         .inclusion_proof(&inclusion_proof_request.identity_commitment)
         .await?;
 
-    let result = result.hide_processed_status();
-
     Ok((result.to_response_code(), Json(result)))
 }
 
@@ -62,8 +60,6 @@ async fn verify_semaphore_proof(
             &verify_semaphore_proof_query,
         )
         .await?;
-
-    let result = result.hide_processed_status();
 
     Ok((result.to_response_code(), Json(result)))
 }

--- a/src/task_monitor/tasks/create_batches.rs
+++ b/src/task_monitor/tasks/create_batches.rs
@@ -15,7 +15,7 @@ use crate::database;
 use crate::database::query::DatabaseQuery as _;
 use crate::database::Database;
 use crate::identity_tree::{
-    AppliedTreeUpdate, Canonical, Hash, TreeVersion, TreeVersionReadOps, TreeWithNextVersion,
+    AppliedTreeUpdate, Hash, Intermediate, TreeVersion, TreeVersionReadOps, TreeWithNextVersion,
 };
 use crate::prover::identity::Identity;
 use crate::prover::repository::ProverRepository;
@@ -187,7 +187,7 @@ async fn ensure_batch_chain_initialized(app: &Arc<App>) -> anyhow::Result<()> {
 async fn commit_identities(
     database: &Database,
     prover_repository: &Arc<ProverRepository>,
-    batching_tree: &TreeVersion<Canonical>,
+    batching_tree: &TreeVersion<Intermediate>,
     next_batch_notify: &Arc<Notify>,
     updates: &[AppliedTreeUpdate],
 ) -> anyhow::Result<()> {
@@ -234,7 +234,7 @@ async fn commit_identities(
 #[instrument(level = "info", skip_all)]
 pub async fn insert_identities(
     database: &Database,
-    batching_tree: &TreeVersion<Canonical>,
+    batching_tree: &TreeVersion<Intermediate>,
     next_batch_notify: &Arc<Notify>,
     updates: &[AppliedTreeUpdate],
     batch_size: usize,
@@ -370,7 +370,7 @@ fn assert_updates_are_consecutive(updates: &[AppliedTreeUpdate]) {
 
 pub async fn delete_identities(
     database: &Database,
-    batching_tree: &TreeVersion<Canonical>,
+    batching_tree: &TreeVersion<Intermediate>,
     next_batch_notify: &Arc<Notify>,
     updates: &[AppliedTreeUpdate],
     batch_size: usize,
@@ -465,7 +465,7 @@ pub async fn delete_identities(
     Ok(())
 }
 
-fn determine_batch_type(tree: &TreeVersion<Canonical>) -> Option<BatchType> {
+fn determine_batch_type(tree: &TreeVersion<Intermediate>) -> Option<BatchType> {
     let next_update = tree.peek_next_updates(1);
     if next_update.is_empty() {
         return None;

--- a/src/task_monitor/tasks/create_batches.rs
+++ b/src/task_monitor/tasks/create_batches.rs
@@ -15,7 +15,7 @@ use crate::database;
 use crate::database::query::DatabaseQuery as _;
 use crate::database::Database;
 use crate::identity_tree::{
-    AppliedTreeUpdate, Hash, Intermediate, TreeVersion, TreeVersionReadOps, TreeWithNextVersion,
+    AppliedTreeUpdate, Canonical, Hash, TreeVersion, TreeVersionReadOps, TreeWithNextVersion,
 };
 use crate::prover::identity::Identity;
 use crate::prover::repository::ProverRepository;
@@ -187,7 +187,7 @@ async fn ensure_batch_chain_initialized(app: &Arc<App>) -> anyhow::Result<()> {
 async fn commit_identities(
     database: &Database,
     prover_repository: &Arc<ProverRepository>,
-    batching_tree: &TreeVersion<Intermediate>,
+    batching_tree: &TreeVersion<Canonical>,
     next_batch_notify: &Arc<Notify>,
     updates: &[AppliedTreeUpdate],
 ) -> anyhow::Result<()> {
@@ -234,7 +234,7 @@ async fn commit_identities(
 #[instrument(level = "info", skip_all)]
 pub async fn insert_identities(
     database: &Database,
-    batching_tree: &TreeVersion<Intermediate>,
+    batching_tree: &TreeVersion<Canonical>,
     next_batch_notify: &Arc<Notify>,
     updates: &[AppliedTreeUpdate],
     batch_size: usize,
@@ -370,7 +370,7 @@ fn assert_updates_are_consecutive(updates: &[AppliedTreeUpdate]) {
 
 pub async fn delete_identities(
     database: &Database,
-    batching_tree: &TreeVersion<Intermediate>,
+    batching_tree: &TreeVersion<Canonical>,
     next_batch_notify: &Arc<Notify>,
     updates: &[AppliedTreeUpdate],
     batch_size: usize,
@@ -465,7 +465,7 @@ pub async fn delete_identities(
     Ok(())
 }
 
-fn determine_batch_type(tree: &TreeVersion<Intermediate>) -> Option<BatchType> {
+fn determine_batch_type(tree: &TreeVersion<Canonical>) -> Option<BatchType> {
     let next_update = tree.peek_next_updates(1);
     if next_update.is_empty() {
         return None;

--- a/src/task_monitor/tasks/finalize_identities.rs
+++ b/src/task_monitor/tasks/finalize_identities.rs
@@ -4,7 +4,12 @@ use crate::app::App;
 
 pub async fn finalize_roots(app: Arc<App>) -> anyhow::Result<()> {
     loop {
-        app.identity_processor.finalize_identities().await?;
+        app.identity_processor
+            .finalize_identities(
+                app.tree_state()?.processed_tree(),
+                app.tree_state()?.mined_tree(),
+            )
+            .await?;
 
         tokio::time::sleep(app.config.app.time_between_scans).await;
     }

--- a/src/task_monitor/tasks/finalize_identities.rs
+++ b/src/task_monitor/tasks/finalize_identities.rs
@@ -4,12 +4,7 @@ use crate::app::App;
 
 pub async fn finalize_roots(app: Arc<App>) -> anyhow::Result<()> {
     loop {
-        app.identity_processor
-            .finalize_identities(
-                app.tree_state()?.processed_tree(),
-                app.tree_state()?.mined_tree(),
-            )
-            .await?;
+        app.identity_processor.finalize_identities().await?;
 
         tokio::time::sleep(app.config.app.time_between_scans).await;
     }

--- a/src/task_monitor/tasks/finalize_identities.rs
+++ b/src/task_monitor/tasks/finalize_identities.rs
@@ -5,10 +5,7 @@ use crate::app::App;
 pub async fn finalize_roots(app: Arc<App>) -> anyhow::Result<()> {
     loop {
         app.identity_processor
-            .finalize_identities(
-                app.tree_state()?.processed_tree(),
-                app.tree_state()?.mined_tree(),
-            )
+            .finalize_identities(app.tree_state()?.processed_tree())
             .await?;
 
         tokio::time::sleep(app.config.app.time_between_scans).await;

--- a/tests/common/abi.rs
+++ b/tests/common/abi.rs
@@ -3,7 +3,7 @@
 use ethers::prelude::abigen;
 
 abigen!(
-    BatchingContract,
+    IWorldIDIdentityManager,
     r#"[
         struct RootInfo { uint256 root; uint128 supersededTimestamp; bool isValid }
         function initialize(uint8 treeDepth, uint256 initialRoot, address _batchInsertionVerifiers, address _batchUpdateVerifiers, address _semaphoreVerifier) public virtual

--- a/tests/common/abi.rs
+++ b/tests/common/abi.rs
@@ -5,10 +5,12 @@ use ethers::prelude::abigen;
 abigen!(
     BatchingContract,
     r#"[
+        struct RootInfo { uint256 root; uint128 supersededTimestamp; bool isValid }
         function initialize(uint8 treeDepth, uint256 initialRoot, address _batchInsertionVerifiers, address _batchUpdateVerifiers, address _semaphoreVerifier) public virtual
         function initializeV2(address _batchDeletionVerifiers) public virtual
         function verifyProof(uint256 root, uint256 signalHash, uint256 nullifierHash, uint256 externalNullifierHash, uint256[8] calldata proof) public view virtual
         function setRootHistoryExpiry(uint256 newExpiryTime) public virtual
+        function queryRoot(uint256 root) public view virtual returns (RootInfo memory)
     ]"#,
     event_derives(serde::Deserialize, serde::Serialize)
 );

--- a/tests/common/chain_mock.rs
+++ b/tests/common/chain_mock.rs
@@ -16,6 +16,7 @@ use ethers::utils::{Anvil, AnvilInstance};
 use ethers_solc::artifacts::BytecodeObject;
 use tracing::{info, instrument};
 
+use super::abi::IWorldIDIdentityManager;
 use super::{abi as ContractAbi, CompiledContract};
 
 pub type SpecialisedContract = Contract<SpecialisedClient>;
@@ -23,7 +24,7 @@ pub type SpecialisedContract = Contract<SpecialisedClient>;
 pub struct MockChain {
     pub anvil:            AnvilInstance,
     pub private_key:      SigningKey,
-    pub identity_manager: SpecialisedContract,
+    pub identity_manager: IWorldIDIdentityManager<SpecialisedClient>,
 }
 
 #[instrument(skip_all)]
@@ -196,7 +197,7 @@ pub async fn spawn_mock_chain(
 
     let identity_manager: SpecialisedContract = Contract::new(
         identity_manager_contract.address(),
-        ContractAbi::BATCHINGCONTRACT_ABI.clone(),
+        ContractAbi::IWORLDIDIDENTITYMANAGER_ABI.clone(),
         client.clone(),
     );
 
@@ -206,6 +207,8 @@ pub async fn spawn_mock_chain(
         .await?
         .await?;
 
+    let identity_manager = IWorldIDIdentityManager::from(identity_manager);
+
     Ok(MockChain {
         anvil: chain,
         private_key,
@@ -213,7 +216,7 @@ pub async fn spawn_mock_chain(
     })
 }
 
-type SpecialisedClient =
+pub type SpecialisedClient =
     NonceManagerMiddleware<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>;
 type SharableClient = Arc<SpecialisedClient>;
 type SpecialisedFactory = ContractFactory<SpecialisedClient>;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -954,21 +954,12 @@ pub async fn test_same_tree_states(
     tree_state2: &TreeState,
 ) -> anyhow::Result<()> {
     assert_eq!(
-        tree_state1.processed_tree().next_leaf(),
-        tree_state2.processed_tree().next_leaf()
+        tree_state1.batching_tree().next_leaf(),
+        tree_state2.batching_tree().next_leaf()
     );
     assert_eq!(
-        tree_state1.processed_tree().get_root(),
-        tree_state2.processed_tree().get_root()
-    );
-
-    assert_eq!(
-        tree_state1.mined_tree().next_leaf(),
-        tree_state2.mined_tree().next_leaf()
-    );
-    assert_eq!(
-        tree_state1.mined_tree().get_root(),
-        tree_state2.mined_tree().get_root()
+        tree_state1.batching_tree().get_root(),
+        tree_state2.batching_tree().get_root()
     );
 
     assert_eq!(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -387,6 +387,8 @@ pub async fn test_not_in_tree(uri: &str, client: &Client<HttpConnector>, leaf: &
         .await
         .expect("Failed to execute request.");
 
+    assert_eq!(response.status(), StatusCode::OK);
+
     let bytes = hyper::body::to_bytes(response.body_mut())
         .await
         .expect("Failed to convert response body to bytes");
@@ -395,8 +397,6 @@ pub async fn test_not_in_tree(uri: &str, client: &Client<HttpConnector>, leaf: &
 
     let result = serde_json::from_str::<InclusionProofResponse>(&result)
         .expect("Failed to parse InclusionProofResponse");
-
-    assert_eq!(response.status(), StatusCode::OK);
 
     assert_eq!(result.root, None);
 }
@@ -417,6 +417,8 @@ pub async fn test_in_tree(uri: &str, client: &Client<HttpConnector>, leaf: &Hash
         .await
         .expect("Failed to execute request.");
 
+    assert_eq!(response.status(), StatusCode::OK);
+
     let bytes = hyper::body::to_bytes(response.body_mut())
         .await
         .expect("Failed to convert response body to bytes");
@@ -425,8 +427,6 @@ pub async fn test_in_tree(uri: &str, client: &Client<HttpConnector>, leaf: &Hash
 
     let result = serde_json::from_str::<InclusionProofResponse>(&result)
         .expect("Failed to parse InclusionProofResponse");
-
-    assert_eq!(response.status(), StatusCode::OK);
 
     let root: U256 = result.root.expect("Failed to get root").into();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -972,12 +972,21 @@ pub async fn test_same_tree_states(
     tree_state2: &TreeState,
 ) -> anyhow::Result<()> {
     assert_eq!(
-        tree_state1.batching_tree().next_leaf(),
-        tree_state2.batching_tree().next_leaf()
+        tree_state1.processed_tree().next_leaf(),
+        tree_state2.processed_tree().next_leaf()
     );
     assert_eq!(
-        tree_state1.batching_tree().get_root(),
-        tree_state2.batching_tree().get_root()
+        tree_state1.processed_tree().get_root(),
+        tree_state2.processed_tree().get_root()
+    );
+
+    assert_eq!(
+        tree_state1.mined_tree().next_leaf(),
+        tree_state2.mined_tree().next_leaf()
+    );
+    assert_eq!(
+        tree_state1.mined_tree().get_root(),
+        tree_state2.mined_tree().get_root()
     );
 
     assert_eq!(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -280,7 +280,7 @@ pub async fn test_inclusion_proof(
         let result = serde_json::from_str::<InclusionProofResponse>(&result)
             .expect("Failed to parse response as json");
 
-        if let Some(root) = result.root {
+        if let Some(root) = result.0.root {
             if offchain_mode_enabled {
                 // For offchain mode returning root in inclusion proof response means the proof
                 // is valid.
@@ -357,7 +357,7 @@ pub async fn test_inclusion_proof_mined(
         let result = serde_json::from_str::<InclusionProofResponse>(&result)
             .expect("Failed to parse response as json");
 
-        if let Some(root) = result.root {
+        if let Some(root) = result.0.root {
             if offchain_mode_enabled {
                 // For offchain mode returning root in inclusion proof response means the proof
                 // is valid.
@@ -414,7 +414,7 @@ pub async fn test_not_in_tree(uri: &str, client: &Client<HttpConnector>, leaf: &
     let result = serde_json::from_str::<InclusionProofResponse>(&result)
         .expect("Failed to parse InclusionProofResponse");
 
-    assert_eq!(result.root, None);
+    assert_eq!(result.0.root, None);
 }
 
 #[instrument(skip_all)]
@@ -444,7 +444,7 @@ pub async fn test_in_tree(uri: &str, client: &Client<HttpConnector>, leaf: &Hash
     let result = serde_json::from_str::<InclusionProofResponse>(&result)
         .expect("Failed to parse InclusionProofResponse");
 
-    let root: U256 = result.root.expect("Failed to get root").into();
+    let root: U256 = result.0.root.expect("Failed to get root").into();
 
     assert_ne!(root, U256::zero(), "Hash is not zero");
 }
@@ -933,11 +933,11 @@ pub fn generate_reference_proof(
     ref_tree: &PoseidonTree,
     leaf_idx: usize,
 ) -> InclusionProofResponse {
-    InclusionProofResponse {
+    InclusionProofResponse(InclusionProof {
         root:    Some(ref_tree.root()),
         proof:   ref_tree.proof(leaf_idx),
         message: None,
-    }
+    })
 }
 
 /// Generates identities for the purposes of testing. The identities are encoded

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -981,12 +981,12 @@ pub async fn test_same_tree_states(
     );
 
     assert_eq!(
-        tree_state1.mined_tree().next_leaf(),
-        tree_state2.mined_tree().next_leaf()
+        tree_state1.batching_tree().next_leaf(),
+        tree_state2.batching_tree().next_leaf()
     );
     assert_eq!(
-        tree_state1.mined_tree().get_root(),
-        tree_state2.mined_tree().get_root()
+        tree_state1.batching_tree().get_root(),
+        tree_state2.batching_tree().get_root()
     );
 
     assert_eq!(

--- a/tests/delete_identities.rs
+++ b/tests/delete_identities.rs
@@ -87,6 +87,7 @@ async fn delete_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
     // Check that we can also get these inclusion proofs back.
     for i in 0..insertion_batch_size {
         test_inclusion_proof(
+            &mock_chain,
             &uri,
             &client,
             i,
@@ -108,6 +109,7 @@ async fn delete_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
     // Ensure that identities have been deleted
     for i in 0..deletion_batch_size {
         test_inclusion_proof(
+            &mock_chain,
             &uri,
             &client,
             i,
@@ -139,6 +141,7 @@ async fn delete_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
     // Ensure that identities have been deleted
     for i in 0..deletion_batch_size {
         test_inclusion_proof(
+            &mock_chain,
             &uri,
             &client,
             i,
@@ -154,6 +157,7 @@ async fn delete_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
     // that have not been deleted
     for i in deletion_batch_size + 1..insertion_batch_size {
         test_inclusion_proof(
+            &mock_chain,
             &uri,
             &client,
             i,

--- a/tests/delete_identities.rs
+++ b/tests/delete_identities.rs
@@ -95,6 +95,7 @@ async fn delete_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
             &Hash::from_str_radix(&test_identities[i], 16)
                 .expect("Failed to parse Hash from test leaf"),
             false,
+            offchain_mode_enabled,
         )
         .await;
     }
@@ -117,6 +118,7 @@ async fn delete_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
             &Hash::from_str_radix(&test_identities[i], 16)
                 .expect("Failed to parse Hash from test leaf"),
             true,
+            offchain_mode_enabled,
         )
         .await;
     }
@@ -149,6 +151,7 @@ async fn delete_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
             &Hash::from_str_radix(&test_identities[i], 16)
                 .expect("Failed to parse Hash from test leaf"),
             true,
+            offchain_mode_enabled,
         )
         .await;
     }
@@ -165,6 +168,7 @@ async fn delete_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
             &Hash::from_str_radix(&test_identities[i], 16)
                 .expect("Failed to parse Hash from test leaf"),
             false,
+            offchain_mode_enabled,
         )
         .await;
     }

--- a/tests/delete_padded_identity.rs
+++ b/tests/delete_padded_identity.rs
@@ -86,6 +86,7 @@ async fn delete_padded_identity(offchain_mode_enabled: bool) -> anyhow::Result<(
     // Check that we can also get these inclusion proofs back.
     for i in 0..insertion_batch_size {
         test_inclusion_proof(
+            &mock_chain,
             &uri,
             &client,
             i,
@@ -108,6 +109,7 @@ async fn delete_padded_identity(offchain_mode_enabled: bool) -> anyhow::Result<(
 
     // make sure that identity 3 wasn't deleted
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         2,
@@ -120,6 +122,7 @@ async fn delete_padded_identity(offchain_mode_enabled: bool) -> anyhow::Result<(
 
     // Ensure that the first and second identities were deleted
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         0,
@@ -130,6 +133,7 @@ async fn delete_padded_identity(offchain_mode_enabled: bool) -> anyhow::Result<(
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         1,

--- a/tests/delete_padded_identity.rs
+++ b/tests/delete_padded_identity.rs
@@ -94,6 +94,7 @@ async fn delete_padded_identity(offchain_mode_enabled: bool) -> anyhow::Result<(
             &Hash::from_str_radix(&test_identities[i], 16)
                 .expect("Failed to parse Hash from test leaf"),
             false,
+            offchain_mode_enabled,
         )
         .await;
     }
@@ -117,6 +118,7 @@ async fn delete_padded_identity(offchain_mode_enabled: bool) -> anyhow::Result<(
         &Hash::from_str_radix(&test_identities[2], 16)
             .expect("Failed to parse Hash from test leaf"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -130,6 +132,7 @@ async fn delete_padded_identity(offchain_mode_enabled: bool) -> anyhow::Result<(
         &Hash::from_str_radix(&test_identities[0], 16)
             .expect("Failed to parse Hash from test leaf"),
         true,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -141,6 +144,7 @@ async fn delete_padded_identity(offchain_mode_enabled: bool) -> anyhow::Result<(
         &Hash::from_str_radix(&test_identities[1], 16)
             .expect("Failed to parse Hash from test leaf"),
         true,
+        offchain_mode_enabled,
     )
     .await;
 

--- a/tests/dynamic_batch_sizes.rs
+++ b/tests/dynamic_batch_sizes.rs
@@ -95,6 +95,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
         &Hash::from_str_radix(&test_identities[0], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -106,6 +107,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
         &Hash::from_str_radix(&test_identities[1], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -117,6 +119,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
         &Hash::from_str_radix(&test_identities[2], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -184,6 +187,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
         &Hash::from_str_radix(&test_identities[3], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -195,6 +199,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
         &Hash::from_str_radix(&test_identities[4], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -224,6 +229,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
         &Hash::from_str_radix(&test_identities[5], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -253,6 +259,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
         &Hash::from_str_radix(&test_identities[6], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 

--- a/tests/dynamic_batch_sizes.rs
+++ b/tests/dynamic_batch_sizes.rs
@@ -87,6 +87,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
 
     // Check that we can get their inclusion proofs back.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         0,
@@ -97,6 +98,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         1,
@@ -107,6 +109,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         2,
@@ -173,6 +176,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
 
     // Check that we can also get these inclusion proofs back.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         3,
@@ -183,6 +187,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         4,
@@ -211,6 +216,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
     tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
 
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         5,
@@ -239,6 +245,7 @@ async fn dynamic_batch_sizes(offchain_mode_enabled: bool) -> anyhow::Result<()> 
     tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
 
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         6,

--- a/tests/immediate_deletion_of_continuous_set_of_identities.rs
+++ b/tests/immediate_deletion_of_continuous_set_of_identities.rs
@@ -20,7 +20,16 @@ const IDLE_TIME: u64 = 7;
 /// in the same batch post root as from the insertion batch 0, 1, 2. This breaks
 /// a central assumption that roots are unique.
 #[tokio::test]
-async fn immediate_deletion_of_continuous_set_of_identities() -> anyhow::Result<()> {
+async fn immediate_deletion_of_continuous_set_of_identities_onchain() -> anyhow::Result<()> {
+    immediate_deletion_of_continuous_set_of_identities(false).await
+}
+
+#[tokio::test]
+async fn immediate_deletion_of_continuous_set_of_identities_offchain() -> anyhow::Result<()> {
+    immediate_deletion_of_continuous_set_of_identities(true).await
+}
+
+async fn immediate_deletion_of_continuous_set_of_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
     // Initialize logging for the test.
     init_tracing_subscriber();
     info!("Starting integration test");
@@ -97,6 +106,7 @@ async fn immediate_deletion_of_continuous_set_of_identities() -> anyhow::Result<
             &Hash::from_str_radix(&test_identities[i], 16)
                 .expect("Failed to parse Hash from test leaf"),
             false,
+            offchain_mode_enabled,
         )
         .await;
     }
@@ -131,6 +141,7 @@ async fn immediate_deletion_of_continuous_set_of_identities() -> anyhow::Result<
         &Hash::from_str_radix(&test_identities[insertion_batch_size - 1], 16)
             .expect("Failed to parse Hash from test leaf"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -147,6 +158,7 @@ async fn immediate_deletion_of_continuous_set_of_identities() -> anyhow::Result<
         &Hash::from_str_radix(&test_identities[insertion_batch_size - 1], 16)
             .expect("Failed to parse Hash from test leaf"),
         true,
+        offchain_mode_enabled,
     )
     .await;
 

--- a/tests/immediate_deletion_of_continuous_set_of_identities.rs
+++ b/tests/immediate_deletion_of_continuous_set_of_identities.rs
@@ -29,7 +29,9 @@ async fn immediate_deletion_of_continuous_set_of_identities_offchain() -> anyhow
     immediate_deletion_of_continuous_set_of_identities(true).await
 }
 
-async fn immediate_deletion_of_continuous_set_of_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
+async fn immediate_deletion_of_continuous_set_of_identities(
+    offchain_mode_enabled: bool,
+) -> anyhow::Result<()> {
     // Initialize logging for the test.
     init_tracing_subscriber();
     info!("Starting integration test");

--- a/tests/immediate_deletion_of_continuous_set_of_identities.rs
+++ b/tests/immediate_deletion_of_continuous_set_of_identities.rs
@@ -89,6 +89,7 @@ async fn immediate_deletion_of_continuous_set_of_identities() -> anyhow::Result<
     // Check that we can also get these inclusion proofs back.
     for i in 0..insertion_batch_size {
         test_inclusion_proof(
+            &mock_chain,
             &uri,
             &client,
             i,
@@ -124,6 +125,7 @@ async fn immediate_deletion_of_continuous_set_of_identities() -> anyhow::Result<
 
     // Ensure the identity has not yet been deleted
     test_inclusion_proof_mined(
+        &mock_chain,
         &uri,
         &client,
         &Hash::from_str_radix(&test_identities[insertion_batch_size - 1], 16)
@@ -139,6 +141,7 @@ async fn immediate_deletion_of_continuous_set_of_identities() -> anyhow::Result<
     tokio::time::sleep(Duration::from_secs(IDLE_TIME * 2)).await;
 
     test_inclusion_proof_mined(
+        &mock_chain,
         &uri,
         &client,
         &Hash::from_str_radix(&test_identities[insertion_batch_size - 1], 16)

--- a/tests/insert_identity_and_proofs.rs
+++ b/tests/insert_identity_and_proofs.rs
@@ -80,6 +80,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
         &ref_tree,
         &config.tree.initial_leaf_value,
         true,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -90,6 +91,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
         &ref_tree,
         &config.tree.initial_leaf_value,
         true,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -110,6 +112,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
         &Hash::from_str_radix(&test_identities[0], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -121,6 +124,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
         &Hash::from_str_radix(&test_identities[1], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -132,6 +136,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
         &Hash::from_str_radix(&test_identities[2], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -153,6 +158,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
         &Hash::from_str_radix(&test_identities[3], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -164,6 +170,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
         &Hash::from_str_radix(&test_identities[4], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -190,6 +197,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
         &Hash::from_str_radix(&test_identities[0], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -201,6 +209,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
         &Hash::from_str_radix(&test_identities[4], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -228,6 +237,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
         &Hash::from_str_radix(&test_identities[0], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -239,6 +249,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
         &Hash::from_str_radix(&test_identities[4], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 

--- a/tests/insert_identity_and_proofs.rs
+++ b/tests/insert_identity_and_proofs.rs
@@ -73,6 +73,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
     // Check that we can get inclusion proofs for things that already exist in the
     // database and on chain.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         0,
@@ -82,6 +83,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         1,
@@ -100,6 +102,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
     tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
     // Check that we can get their inclusion proofs back.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         0,
@@ -110,6 +113,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         1,
@@ -120,6 +124,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         2,
@@ -140,6 +145,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
     tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
     // Check that we can also get these inclusion proofs back.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         3,
@@ -150,6 +156,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         4,
@@ -175,6 +182,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
     // Check that we can still get inclusion proofs for identities we know to have
     // been inserted previously. Here we check the first and last ones we inserted.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         0,
@@ -185,6 +193,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         4,
@@ -211,6 +220,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
     // Check that we can still get inclusion proofs for identities we know to have
     // been inserted previously. Here we check the first and last ones we inserted.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         0,
@@ -221,6 +231,7 @@ async fn insert_identity_and_proofs(offchain_mode_enabled: bool) -> anyhow::Resu
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         4,

--- a/tests/more_identities_than_dense_prefix.rs
+++ b/tests/more_identities_than_dense_prefix.rs
@@ -89,10 +89,20 @@ async fn more_identities_than_dense_prefix(offchain_mode_enabled: bool) -> anyho
     tokio::time::sleep(Duration::from_secs(IDLE_TIME * num_batches_total as u64)).await;
 
     // Check that we can get inclusion proof for the first identity
-    test_inclusion_proof(&uri, &client, 0, &ref_tree, &identities_ref[0], false).await;
+    test_inclusion_proof(
+        &mock_chain,
+        &uri,
+        &client,
+        0,
+        &ref_tree,
+        &identities_ref[0],
+        false,
+    )
+    .await;
 
     // Check that we can get inclusion proof for the last identity
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         num_identities_total - 1,
@@ -125,10 +135,20 @@ async fn more_identities_than_dense_prefix(offchain_mode_enabled: bool) -> anyho
     tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
 
     // Check that we can get inclusion proof for the first identity
-    test_inclusion_proof(&uri, &client, 0, &ref_tree, &identities_ref[0], false).await;
+    test_inclusion_proof(
+        &mock_chain,
+        &uri,
+        &client,
+        0,
+        &ref_tree,
+        &identities_ref[0],
+        false,
+    )
+    .await;
 
     // Check that we can get inclusion proof for the last identity
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         num_identities_total - 1,

--- a/tests/more_identities_than_dense_prefix.rs
+++ b/tests/more_identities_than_dense_prefix.rs
@@ -97,6 +97,7 @@ async fn more_identities_than_dense_prefix(offchain_mode_enabled: bool) -> anyho
         &ref_tree,
         &identities_ref[0],
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -109,6 +110,7 @@ async fn more_identities_than_dense_prefix(offchain_mode_enabled: bool) -> anyho
         &ref_tree,
         &identities_ref[num_identities_total - 1],
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -143,6 +145,7 @@ async fn more_identities_than_dense_prefix(offchain_mode_enabled: bool) -> anyho
         &ref_tree,
         &identities_ref[0],
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -155,6 +158,7 @@ async fn more_identities_than_dense_prefix(offchain_mode_enabled: bool) -> anyho
         &ref_tree,
         &identities_ref[num_identities_total - 1],
         false,
+        offchain_mode_enabled,
     )
     .await;
 

--- a/tests/multi_prover.rs
+++ b/tests/multi_prover.rs
@@ -90,7 +90,7 @@ async fn multi_prover(offchain_mode_enabled: bool) -> anyhow::Result<()> {
 
     // Identities should have been inserted and processed
     for (i, identity) in identities_ref.iter().enumerate().take(batch_size_3) {
-        test_inclusion_proof(&uri, &client, i, &ref_tree, identity, false).await;
+        test_inclusion_proof(&mock_chain, &uri, &client, i, &ref_tree, identity, false).await;
     }
 
     // Now re re-enable the larger prover and disable the smaller one
@@ -109,6 +109,7 @@ async fn multi_prover(offchain_mode_enabled: bool) -> anyhow::Result<()> {
     // Identities should have been inserted and processed
     for i in 0..batch_size_10 {
         test_inclusion_proof(
+            &mock_chain,
             &uri,
             &client,
             offset + i,

--- a/tests/multi_prover.rs
+++ b/tests/multi_prover.rs
@@ -90,7 +90,17 @@ async fn multi_prover(offchain_mode_enabled: bool) -> anyhow::Result<()> {
 
     // Identities should have been inserted and processed
     for (i, identity) in identities_ref.iter().enumerate().take(batch_size_3) {
-        test_inclusion_proof(&mock_chain, &uri, &client, i, &ref_tree, identity, false).await;
+        test_inclusion_proof(
+            &mock_chain,
+            &uri,
+            &client,
+            i,
+            &ref_tree,
+            identity,
+            false,
+            offchain_mode_enabled,
+        )
+        .await;
     }
 
     // Now re re-enable the larger prover and disable the smaller one
@@ -116,6 +126,7 @@ async fn multi_prover(offchain_mode_enabled: bool) -> anyhow::Result<()> {
             &ref_tree,
             &identities_ref[i + offset],
             false,
+            offchain_mode_enabled,
         )
         .await;
     }

--- a/tests/recover_identities.rs
+++ b/tests/recover_identities.rs
@@ -3,8 +3,6 @@
 mod common;
 
 use common::prelude::*;
-use signup_sequencer::identity_tree::{ProcessedStatus, UnprocessedStatus};
-use tracing::debug;
 
 use crate::common::{test_in_tree, test_not_in_tree, test_recover_identity};
 

--- a/tests/recover_identities.rs
+++ b/tests/recover_identities.rs
@@ -170,12 +170,6 @@ async fn recover_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
         test_not_in_tree(&uri, &client, &identities_ref[recovery_leaf_index]).await;
     }
 
-    // // Update ref tree with changes that will be done in background
-    // for i in 0..deletion_batch_size {
-    //     let recovery_leaf_index = insertion_batch_size + i;
-    //     ref_tree.set(recovery_leaf_index, identities_ref[recovery_leaf_index]);
-    // }
-
     // Sleep for root expiry
     tokio::time::sleep(Duration::from_secs(updated_root_history_expiry.as_u64())).await;
 

--- a/tests/recover_identities.rs
+++ b/tests/recover_identities.rs
@@ -107,6 +107,7 @@ async fn recover_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
             &ref_tree,
             &identities_ref[i],
             false,
+            offchain_mode_enabled,
         )
         .await;
     }
@@ -160,6 +161,7 @@ async fn recover_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
             &ref_tree,
             &identities_ref[i],
             true,
+            offchain_mode_enabled,
         )
         .await;
 

--- a/tests/recover_identities.rs
+++ b/tests/recover_identities.rs
@@ -3,6 +3,8 @@
 mod common;
 
 use common::prelude::*;
+use signup_sequencer::identity_tree::{ProcessedStatus, UnprocessedStatus};
+use tracing::debug;
 
 use crate::common::{test_in_tree, test_not_in_tree, test_recover_identity};
 

--- a/tests/recover_identities.rs
+++ b/tests/recover_identities.rs
@@ -4,8 +4,9 @@ mod common;
 
 use common::prelude::*;
 use signup_sequencer::identity_tree::{ProcessedStatus, UnprocessedStatus};
+use tracing::debug;
 
-use crate::common::{test_inclusion_status, test_recover_identity};
+use crate::common::{test_in_tree, test_not_in_tree, test_recover_identity};
 
 const IDLE_TIME: u64 = 7;
 
@@ -84,8 +85,15 @@ async fn recover_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
 
     let mut next_leaf_index = 0;
     // Insert enough identities to trigger an batch to be sent to the blockchain.
-    for i in 0..insertion_batch_size {
-        test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, i).await;
+    for _ in 0..insertion_batch_size {
+        test_insert_identity(
+            &uri,
+            &client,
+            &mut ref_tree,
+            &identities_ref,
+            next_leaf_index,
+        )
+        .await;
 
         next_leaf_index += 1;
     }
@@ -93,7 +101,16 @@ async fn recover_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
     tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
     // Check that we can also get these inclusion proofs back.
     for i in 0..insertion_batch_size {
-        test_inclusion_proof(&uri, &client, i, &ref_tree, &identities_ref[i], false).await;
+        test_inclusion_proof(
+            &mock_chain,
+            &uri,
+            &client,
+            i,
+            &ref_tree,
+            &identities_ref[i],
+            false,
+        )
+        .await;
     }
 
     // Test that we cannot recover with an identity that has previously been
@@ -117,7 +134,6 @@ async fn recover_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
         // Delete the identity at i and replace it with an identity at the back of the
         //  test identities array
         // TODO: we should update to a much cleaner approach
-        let recovery_leaf_index = test_identities.len() - i - 1;
 
         test_recover_identity(
             &uri,
@@ -125,7 +141,7 @@ async fn recover_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
             &mut ref_tree,
             &identities_ref,
             i,
-            identities_ref[recovery_leaf_index],
+            identities_ref[next_leaf_index],
             next_leaf_index,
             false,
         )
@@ -138,26 +154,41 @@ async fn recover_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
 
     // Ensure that identities have been deleted
     for i in 0..deletion_batch_size {
-        let recovery_leaf_index = test_identities.len() - i - 1;
-
-        test_inclusion_proof(&uri, &client, i, &ref_tree, &identities_ref[i], true).await;
-
-        // Check that the replacement identity has not been inserted yet
-        test_inclusion_status(
+        test_inclusion_proof(
+            &mock_chain,
             &uri,
             &client,
-            &identities_ref[recovery_leaf_index],
-            UnprocessedStatus::New,
+            i,
+            &ref_tree,
+            &identities_ref[i],
+            true,
         )
         .await;
+
+        // Check that the replacement identity has not been inserted yet
+        let recovery_leaf_index = insertion_batch_size + i;
+        test_not_in_tree(&uri, &client, &identities_ref[recovery_leaf_index]).await;
     }
+
+    // // Update ref tree with changes that will be done in background
+    // for i in 0..deletion_batch_size {
+    //     let recovery_leaf_index = insertion_batch_size + i;
+    //     ref_tree.set(recovery_leaf_index, identities_ref[recovery_leaf_index]);
+    // }
 
     // Sleep for root expiry
     tokio::time::sleep(Duration::from_secs(updated_root_history_expiry.as_u64())).await;
 
-    // Insert enough identities to trigger an batch to be sent to the blockchain.
-    for i in insertion_batch_size..insertion_batch_size * 2 {
-        test_insert_identity(&uri, &client, &mut ref_tree, &identities_ref, i).await;
+    // Insert enough identities to trigger a batch to be sent to the blockchain.
+    for _ in 0..insertion_batch_size {
+        test_insert_identity(
+            &uri,
+            &client,
+            &mut ref_tree,
+            &identities_ref,
+            next_leaf_index,
+        )
+        .await;
         next_leaf_index += 1;
     }
 
@@ -165,17 +196,11 @@ async fn recover_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
 
     // Check that the replacement identities have been inserted
     for i in 0..deletion_batch_size {
-        let recovery_leaf_index = test_identities.len() - i - 1;
+        let recovery_leaf_index = insertion_batch_size + i;
 
         // Check that the replacement identity has a mined status after an insertion
         // batch has completed
-        test_inclusion_status(
-            &uri,
-            &client,
-            &identities_ref[recovery_leaf_index],
-            ProcessedStatus::Mined,
-        )
-        .await;
+        test_in_tree(&uri, &client, &identities_ref[recovery_leaf_index]).await;
     }
 
     // Shutdown the app properly for the final time

--- a/tests/recover_identities.rs
+++ b/tests/recover_identities.rs
@@ -39,7 +39,7 @@ async fn recover_identities(offchain_mode_enabled: bool) -> anyhow::Result<()> {
     let updated_root_history_expiry = U256::from(30);
     mock_chain
         .identity_manager
-        .method::<_, ()>("setRootHistoryExpiry", updated_root_history_expiry)?
+        .set_root_history_expiry(updated_root_history_expiry)
         .send()
         .await?
         .await?;

--- a/tests/tree_restore_with_root_back_to_init.rs
+++ b/tests/tree_restore_with_root_back_to_init.rs
@@ -81,6 +81,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
         &Hash::from_str_radix(&test_identities[0], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -92,6 +93,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
         &Hash::from_str_radix(&test_identities[1], 16)
             .expect("Failed to parse Hash from test leaf 1"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -103,6 +105,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
         &Hash::from_str_radix(&test_identities[2], 16)
             .expect("Failed to parse Hash from test leaf 2"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -170,6 +173,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
         &Hash::from_str_radix(&test_identities[0], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -181,6 +185,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
         &Hash::from_str_radix(&test_identities[1], 16)
             .expect("Failed to parse Hash from test leaf 1"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -192,6 +197,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
         &Hash::from_str_radix(&test_identities[2], 16)
             .expect("Failed to parse Hash from test leaf 2"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 

--- a/tests/tree_restore_with_root_back_to_init.rs
+++ b/tests/tree_restore_with_root_back_to_init.rs
@@ -160,6 +160,14 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
         restored_tree_state.batching_tree().get_root(),
         initial_root.into()
     );
+    assert_eq!(
+        restored_tree_state.mined_tree().get_root(),
+        initial_root.into()
+    );
+    assert_eq!(
+        restored_tree_state.processed_tree().get_root(),
+        initial_root.into()
+    );
 
     tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
 

--- a/tests/tree_restore_with_root_back_to_init.rs
+++ b/tests/tree_restore_with_root_back_to_init.rs
@@ -73,6 +73,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
 
     // Check that we can also get these inclusion proofs back.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         0,
@@ -83,6 +84,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         1,
@@ -93,6 +95,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         2,
@@ -102,6 +105,8 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
         false,
     )
     .await;
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     let tree_state = app.tree_state()?.clone();
 
@@ -165,6 +170,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
 
     // Check that we can also get these inclusion proofs back.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         0,
@@ -175,6 +181,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         1,
@@ -185,6 +192,7 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         2,
@@ -194,6 +202,8 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
         false,
     )
     .await;
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     test_same_tree_states(&tree_state, &restored_tree_state).await?;
 

--- a/tests/tree_restore_with_root_back_to_init.rs
+++ b/tests/tree_restore_with_root_back_to_init.rs
@@ -157,14 +157,6 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
         restored_tree_state.batching_tree().get_root(),
         initial_root.into()
     );
-    assert_eq!(
-        restored_tree_state.mined_tree().get_root(),
-        initial_root.into()
-    );
-    assert_eq!(
-        restored_tree_state.processed_tree().get_root(),
-        initial_root.into()
-    );
 
     tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
 

--- a/tests/tree_restore_with_root_back_to_init.rs
+++ b/tests/tree_restore_with_root_back_to_init.rs
@@ -161,10 +161,6 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
         initial_root.into()
     );
     assert_eq!(
-        restored_tree_state.mined_tree().get_root(),
-        initial_root.into()
-    );
-    assert_eq!(
         restored_tree_state.processed_tree().get_root(),
         initial_root.into()
     );

--- a/tests/tree_restore_with_root_back_to_middle.rs
+++ b/tests/tree_restore_with_root_back_to_middle.rs
@@ -206,7 +206,6 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         restored_tree_state.batching_tree().get_root(),
         mid_root.into()
     );
-    assert_eq!(restored_tree_state.mined_tree().get_root(), mid_root.into());
     assert_eq!(
         restored_tree_state.processed_tree().get_root(),
         mid_root.into()

--- a/tests/tree_restore_with_root_back_to_middle.rs
+++ b/tests/tree_restore_with_root_back_to_middle.rs
@@ -73,6 +73,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
 
     // Check that we can also get these inclusion proofs back.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         0,
@@ -83,6 +84,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         1,
@@ -93,6 +95,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         2,
@@ -102,6 +105,8 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         false,
     )
     .await;
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     let mid_root: U256 = ref_tree.root().into();
 
@@ -113,6 +118,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
 
     // Check that we can also get these inclusion proofs back.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         3,
@@ -123,6 +129,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         4,
@@ -133,6 +140,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         5,
@@ -142,6 +150,8 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         false,
     )
     .await;
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     let tree_state = app.tree_state()?.clone();
 
@@ -200,6 +210,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
 
     // Check that we can also get these inclusion proofs back.
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         3,
@@ -210,6 +221,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         4,
@@ -220,6 +232,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
     )
     .await;
     test_inclusion_proof(
+        &mock_chain,
         &uri,
         &client,
         5,
@@ -229,6 +242,8 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         false,
     )
     .await;
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     test_same_tree_states(&tree_state, &restored_tree_state).await?;
 

--- a/tests/tree_restore_with_root_back_to_middle.rs
+++ b/tests/tree_restore_with_root_back_to_middle.rs
@@ -81,6 +81,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         &Hash::from_str_radix(&test_identities[0], 16)
             .expect("Failed to parse Hash from test leaf 0"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -92,6 +93,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         &Hash::from_str_radix(&test_identities[1], 16)
             .expect("Failed to parse Hash from test leaf 1"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -103,6 +105,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         &Hash::from_str_radix(&test_identities[2], 16)
             .expect("Failed to parse Hash from test leaf 2"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -126,6 +129,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         &Hash::from_str_radix(&test_identities[3], 16)
             .expect("Failed to parse Hash from test leaf 3"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -137,6 +141,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         &Hash::from_str_radix(&test_identities[4], 16)
             .expect("Failed to parse Hash from test leaf 4"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -148,6 +153,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         &Hash::from_str_radix(&test_identities[5], 16)
             .expect("Failed to parse Hash from test leaf 5"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 
@@ -213,6 +219,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         &Hash::from_str_radix(&test_identities[3], 16)
             .expect("Failed to parse Hash from test leaf 3"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -224,6 +231,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         &Hash::from_str_radix(&test_identities[4], 16)
             .expect("Failed to parse Hash from test leaf 4"),
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -235,6 +243,7 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         &Hash::from_str_radix(&test_identities[5], 16)
             .expect("Failed to parse Hash from test leaf 5"),
         false,
+        offchain_mode_enabled,
     )
     .await;
 

--- a/tests/tree_restore_with_root_back_to_middle.rs
+++ b/tests/tree_restore_with_root_back_to_middle.rs
@@ -206,6 +206,11 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         restored_tree_state.batching_tree().get_root(),
         mid_root.into()
     );
+    assert_eq!(restored_tree_state.mined_tree().get_root(), mid_root.into());
+    assert_eq!(
+        restored_tree_state.processed_tree().get_root(),
+        mid_root.into()
+    );
 
     tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
 

--- a/tests/tree_restore_with_root_back_to_middle.rs
+++ b/tests/tree_restore_with_root_back_to_middle.rs
@@ -200,11 +200,6 @@ async fn tree_restore_with_root_back_to_middle(offchain_mode_enabled: bool) -> a
         restored_tree_state.batching_tree().get_root(),
         mid_root.into()
     );
-    assert_eq!(restored_tree_state.mined_tree().get_root(), mid_root.into());
-    assert_eq!(
-        restored_tree_state.processed_tree().get_root(),
-        mid_root.into()
-    );
 
     tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
 

--- a/tests/unavailable_prover.rs
+++ b/tests/unavailable_prover.rs
@@ -95,6 +95,7 @@ async fn unavailable_prover(offchain_mode_enabled: bool) -> anyhow::Result<()> {
         &ref_tree,
         &identities_ref[0],
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -105,6 +106,7 @@ async fn unavailable_prover(offchain_mode_enabled: bool) -> anyhow::Result<()> {
         &ref_tree,
         &identities_ref[1],
         false,
+        offchain_mode_enabled,
     )
     .await;
     test_inclusion_proof(
@@ -115,6 +117,7 @@ async fn unavailable_prover(offchain_mode_enabled: bool) -> anyhow::Result<()> {
         &ref_tree,
         &identities_ref[2],
         false,
+        offchain_mode_enabled,
     )
     .await;
 

--- a/tests/unavailable_prover.rs
+++ b/tests/unavailable_prover.rs
@@ -87,9 +87,36 @@ async fn unavailable_prover(offchain_mode_enabled: bool) -> anyhow::Result<()> {
     info!("Prover has been reenabled");
 
     // Test that the identities have been inserted and processed
-    test_inclusion_proof(&uri, &client, 0, &ref_tree, &identities_ref[0], false).await;
-    test_inclusion_proof(&uri, &client, 1, &ref_tree, &identities_ref[1], false).await;
-    test_inclusion_proof(&uri, &client, 2, &ref_tree, &identities_ref[2], false).await;
+    test_inclusion_proof(
+        &mock_chain,
+        &uri,
+        &client,
+        0,
+        &ref_tree,
+        &identities_ref[0],
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &mock_chain,
+        &uri,
+        &client,
+        1,
+        &ref_tree,
+        &identities_ref[1],
+        false,
+    )
+    .await;
+    test_inclusion_proof(
+        &mock_chain,
+        &uri,
+        &client,
+        2,
+        &ref_tree,
+        &identities_ref[2],
+        false,
+    )
+    .await;
 
     shutdown.shutdown();
     app_handle.await?;

--- a/tests/validate_proofs.rs
+++ b/tests/validate_proofs.rs
@@ -118,7 +118,16 @@ async fn validate_proofs(offchain_mode_enabled: bool) -> anyhow::Result<()> {
     )
     .await;
 
-    test_inclusion_proof(&uri, &client, 0, &ref_tree, &TEST_LEAVES[0], false).await;
+    test_inclusion_proof(
+        &mock_chain,
+        &uri,
+        &client,
+        0,
+        &ref_tree,
+        &TEST_LEAVES[0],
+        false,
+    )
+    .await;
 
     if !offchain_mode_enabled {
         test_verify_proof_on_chain(

--- a/tests/validate_proofs.rs
+++ b/tests/validate_proofs.rs
@@ -126,6 +126,7 @@ async fn validate_proofs(offchain_mode_enabled: bool) -> anyhow::Result<()> {
         &ref_tree,
         &TEST_LEAVES[0],
         false,
+        offchain_mode_enabled,
     )
     .await;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Status field is no longer used and removing it will help to simplify the project.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Removed status field from all responses.
Removed mined tree (as no longer used).
The source of leaf ids for recovery is now a database instead of processed tree.
Tests are changed to not use status field:
* for on-chain mode identity is considered processed when root is returned for `/inclusionProof` request and can be verified on chain using `queryRoot` contract method (mocked chain for testing)
* for off-chain mode identity is considered processed when root is returned for `/inclusionProof` request (no checking on chain)

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
