### PR TITLE
retry_tx fix

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -23,12 +23,12 @@ use crate::identity_tree::{
 use crate::prover::map::initialize_prover_maps;
 use crate::prover::repository::ProverRepository;
 use crate::prover::{ProverConfig, ProverType};
+use crate::retry_tx;
 use crate::server::data::{
     InclusionProofResponse, ListBatchSizesResponse, VerifySemaphoreProofQuery,
     VerifySemaphoreProofRequest, VerifySemaphoreProofResponse,
 };
 use crate::server::error::Error as ServerError;
-use crate::utils::retry_tx;
 
 pub struct App {
     pub database:           Arc<Database>,

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -4,7 +4,7 @@ use tracing::instrument;
 use crate::database::query::DatabaseQuery;
 use crate::database::{Database, Error};
 use crate::identity_tree::{Hash, ProcessedStatus};
-use crate::utils::retry_tx;
+use crate::retry_tx;
 
 async fn mark_root_as_processed(
     tx: &mut Transaction<'_, Postgres>,
@@ -96,7 +96,7 @@ impl Database {
         retry_tx!(self.pool, tx, {
             mark_root_as_processed(&mut tx, root).await?;
             tx.delete_batches_after_root(root).await?;
-            Ok(())
+            Result::<_, Error>::Ok(())
         })
         .await
     }

--- a/src/identity/processor.rs
+++ b/src/identity/processor.rs
@@ -24,8 +24,8 @@ use crate::identity_tree::{Canonical, Hash, Intermediate, TreeVersion, TreeWithN
 use crate::prover::identity::Identity;
 use crate::prover::repository::ProverRepository;
 use crate::prover::Prover;
+use crate::retry_tx;
 use crate::utils::index_packing::pack_indices;
-use crate::utils::retry_tx;
 
 pub type TransactionId = String;
 
@@ -549,7 +549,7 @@ impl OnChainIdentityProcessor {
                     .await?;
             }
 
-            Ok(())
+            Result::<_, anyhow::Error>::Ok(())
         })
         .await
     }
@@ -648,7 +648,7 @@ impl OffChainIdentityProcessor {
                     .await?;
             }
 
-            Ok(())
+            Result::<_, anyhow::Error>::Ok(())
         })
         .await
     }

--- a/src/task_monitor/tasks/insert_identities.rs
+++ b/src/task_monitor/tasks/insert_identities.rs
@@ -10,7 +10,7 @@ use crate::database::query::DatabaseQuery as _;
 use crate::database::types::UnprocessedCommitment;
 use crate::database::Database;
 use crate::identity_tree::{Latest, TreeVersion, TreeVersionReadOps, UnprocessedStatus};
-use crate::utils::retry_tx;
+use crate::retry_tx;
 
 pub async fn insert_identities(
     app: Arc<App>,
@@ -100,7 +100,7 @@ pub async fn insert_identities_batch(
             tx.remove_unprocessed_identity(identity).await?;
         }
 
-        Ok(())
+        Result::<_, anyhow::Error>::Ok(())
     })
     .await
 }

--- a/tests/serializable_transaction.rs
+++ b/tests/serializable_transaction.rs
@@ -1,0 +1,144 @@
+mod common;
+use common::prelude::*;
+use futures::stream::StreamExt;
+use signup_sequencer::retry_tx;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{Postgres, Transaction};
+use tokio::time::{sleep, Duration};
+
+async fn setup(pool: &sqlx::Pool<Postgres>) -> Result<(), sqlx::Error> {
+    retry_tx!(pool, tx, {
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS accounts (
+                id SERIAL PRIMARY KEY,
+                balance INT
+            );
+            "#,
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query("TRUNCATE TABLE accounts RESTART IDENTITY;")
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query("INSERT INTO accounts (balance) VALUES (100), (200);")
+            .execute(&mut *tx)
+            .await?;
+
+        Result::<_, anyhow::Error>::Ok(())
+    })
+    .await
+    .unwrap();
+
+    Ok(())
+}
+
+async fn transaction_1(pool: &sqlx::Pool<Postgres>) -> Result<(), sqlx::Error> {
+    retry_tx!(pool, tx, {
+        sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+            .execute(&mut *tx)
+            .await?;
+
+        let balance: (i32,) = sqlx::query_as("SELECT balance FROM accounts WHERE id = 1")
+            .fetch_one(&mut *tx)
+            .await?;
+
+        println!("Transaction 1: Balance of account 1 is {}", balance.0);
+
+        // Simulate some work
+        sleep(Duration::from_secs(5)).await;
+
+        sqlx::query("UPDATE accounts SET balance = balance + 30 WHERE id = 2")
+            .execute(&mut *tx)
+            .await?;
+
+        Result::<_, anyhow::Error>::Ok(())
+    })
+    .await
+    .unwrap();
+
+    Ok(())
+}
+
+async fn transaction_2(pool: &sqlx::Pool<Postgres>) -> Result<(), sqlx::Error> {
+    let mut tx: Transaction<'_, Postgres> = pool.begin().await?;
+
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .execute(&mut *tx)
+        .await?;
+
+    let balance: (i32,) = sqlx::query_as("SELECT balance FROM accounts WHERE id = 2")
+        .fetch_one(&mut *tx)
+        .await?;
+
+    println!("Transaction 2: Balance of account 2 is {}", balance.0);
+
+    sqlx::query("UPDATE accounts SET balance = balance + 50 WHERE id = 1")
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn serializable_transaction() -> Result<(), anyhow::Error> {
+    init_tracing_subscriber();
+    info!("Starting serializable_transaction");
+
+    let insertion_batch_size: usize = 500;
+    let deletion_batch_size: usize = 10;
+
+    let ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
+    let initial_root: U256 = ref_tree.root().into();
+
+    let docker = Cli::default();
+    let (mock_chain, db_container, _insertion_prover_map, _deletion_prover_map, micro_oz) =
+        spawn_deps(
+            initial_root,
+            &[insertion_batch_size],
+            &[deletion_batch_size],
+            DEFAULT_TREE_DEPTH as u8,
+            &docker,
+        )
+        .await?;
+
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
+
+    let temp_dir = tempfile::tempdir()?;
+    info!(
+        "temp dir created at: {:?}",
+        temp_dir.path().join("testfile")
+    );
+
+    let config = TestConfigBuilder::new()
+        .db_url(&db_url)
+        .oz_api_url(&micro_oz.endpoint())
+        .oz_address(micro_oz.address())
+        .identity_manager_address(mock_chain.identity_manager.address())
+        .primary_network_provider(mock_chain.anvil.endpoint())
+        .cache_file(temp_dir.path().join("testfile").to_str().unwrap())
+        .build()?;
+
+    let (..) = spawn_app(config.clone())
+        .await
+        .expect("Failed to spawn app.");
+
+    let pool = PgPoolOptions::new()
+        .max_connections(100)
+        .connect(&db_url)
+        .await?;
+
+    setup(&pool).await?;
+    futures::stream::iter(0..2)
+        .for_each_concurrent(None, |_| async {
+            transaction_1(&pool).await.unwrap();
+            transaction_2(&pool).await.unwrap();
+        })
+        .await;
+
+    Ok(())
+}


### PR DESCRIPTION
This should fix the behaviour of `retry_tx!`. I've also added a test to check to make sure it's working properly. I attempted to recreate the serialization errors within our integration tests using our normal workflow but was unable to.
