### PR TITLE
Graceful Shutdown

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ on:
     branches:
       - main
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
     branches:
       - main
 
 env:
-  RUST_VERSION: "1.81.0"
+  RUST_VERSION: "1.82.0"
   CARGO_TERM_COLOR: always
   # Skip incremental build and debug info generation in CI
   CARGO_INCREMENTAL: 0
@@ -108,7 +108,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     env:
-      CARGO_VET_VERSION: 0.9.0
+      CARGO_VET_VERSION: 0.9.1
     steps:
       - uses: actions/checkout@master
       - name: Install Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6131,6 +6131,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml 0.8.19",
+ "tower-http",
  "tracing",
  "tracing-futures",
  "tracing-subscriber 0.3.18",
@@ -7102,6 +7103,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 0.1.2",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ async-stream = "0.3.3"
 async-trait = "0.1.64"
 axum = "0.7.7"
 axum-server = "0.7.1"
+tower-http = { version = "0.6", features = ["catch-panic"] }
 bytes = "1.4.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "4.0", features = ["derive", "env"] }
@@ -103,10 +104,6 @@ tracing-test = "0.2"
 ruint = { git = "https://github.com/Dzejkop/uint", rev = "9a1a6019c519e9cd76add2494190d21fc5f574f9" }
 
 [profile.release]
-panic = "abort"
 overflow-checks = true
 lto = "thin"
 debug = true
-
-[profile.dev]
-panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ async-stream = "0.3.3"
 async-trait = "0.1.64"
 axum = "0.7.7"
 axum-server = "0.7.1"
-tower-http = { version = "0.6", features = ["catch-panic"] }
+tower-http = { version = "0.6.1", features = ["catch-panic"] }
 bytes = "1.4.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "4.0", features = ["derive", "env"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,7 +87,7 @@ pub struct AppConfig {
     pub monitored_txs_capacity: usize,
 
     /// The durtaion to wait for tasks to shutdown
-    /// bofore timing out
+    /// before timing out
     #[serde(with = "humantime_serde")]
     #[serde(default = "default::shutdown_timeout")]
     pub shutdown_timeout: Duration,

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,19 @@ pub struct AppConfig {
     /// The number of txs in the channel that we'll be monitoring
     #[serde(default = "default::monitored_txs_capacity")]
     pub monitored_txs_capacity: usize,
+
+    /// The durtaion to wait for tasks to shutdown
+    /// bofore timing out
+    #[serde(with = "humantime_serde")]
+    #[serde(default = "default::shutdown_timeout")]
+    pub shutdown_timeout: Duration,
+
+    /// The minimum amount of time to wait after a shutdown
+    /// is innitiated before the process exits. This is useful to
+    /// give cancelled tasks a chance to get to an await point.
+    #[serde(with = "humantime_serde")]
+    #[serde(default = "default::shutdown_delay")]
+    pub shutdown_delay: Duration,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -284,6 +297,14 @@ pub mod default {
         Duration::from_secs(30)
     }
 
+    pub fn shutdown_timeout() -> Duration {
+        Duration::from_secs(30)
+    }
+
+    pub fn shutdown_delay() -> Duration {
+        Duration::from_secs(1)
+    }
+
     pub fn monitored_txs_capacity() -> usize {
         100
     }
@@ -363,6 +384,8 @@ mod tests {
         scanning_chain_head_offset = 0
         time_between_scans = "30s"
         monitored_txs_capacity = 100
+        shutdown_timeout = "30s"
+        shutdown_delay = "1s"
 
         [tree]
         tree_depth = 30
@@ -415,6 +438,8 @@ mod tests {
         scanning_chain_head_offset = 0
         time_between_scans = "30s"
         monitored_txs_capacity = 100
+        shutdown_timeout = "30s"
+        shutdown_delay = "1s"
 
         [tree]
         tree_depth = 30
@@ -452,6 +477,8 @@ mod tests {
         SEQ__APP__SCANNING_CHAIN_HEAD_OFFSET=0
         SEQ__APP__TIME_BETWEEN_SCANS=30s
         SEQ__APP__MONITORED_TXS_CAPACITY=100
+        SEQ__APP__SHUTDOWN_TIMEOUT=30s
+        SEQ__APP__SHUTDOWN_DELAY=1s
 
         SEQ__TREE__TREE_DEPTH=30
         SEQ__TREE__DENSE_TREE_PREFIX_DEPTH=20
@@ -494,6 +521,8 @@ mod tests {
         SEQ__APP__SCANNING_CHAIN_HEAD_OFFSET=0
         SEQ__APP__TIME_BETWEEN_SCANS=30s
         SEQ__APP__MONITORED_TXS_CAPACITY=100
+        SEQ__APP__SHUTDOWN_TIMEOUT=30s
+        SEQ__APP__SHUTDOWN_DELAY=1s
 
         SEQ__TREE__TREE_DEPTH=30
         SEQ__TREE__DENSE_TREE_PREFIX_DEPTH=20

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,12 @@
 )]
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use clap::Parser;
 use signup_sequencer::app::App;
 use signup_sequencer::config::{load_config, ServiceConfig};
 use signup_sequencer::server;
-use signup_sequencer::shutdown::{watch_shutdown_signals, Shutdown};
+use signup_sequencer::shutdown::Shutdown;
 use signup_sequencer::task_monitor::TaskMonitor;
 use telemetry_batteries::tracing::datadog::DatadogBattery;
 use telemetry_batteries::tracing::stdout::StdoutBattery;
@@ -38,9 +37,7 @@ async fn sequencer_app(args: Args) -> anyhow::Result<()> {
 
     let _tracing_shutdown_handle = init_telemetry(&config.service)?;
 
-    let shutdown = Arc::new(Shutdown::new());
-
-    watch_shutdown_signals(shutdown.clone());
+    let shutdown = Shutdown::spawn(config.app.shutdown_timeout, config.app.shutdown_delay);
 
     let version = env!("GIT_VERSION");
 
@@ -51,16 +48,14 @@ async fn sequencer_app(args: Args) -> anyhow::Result<()> {
     // Create App struct
     let app = App::new(config).await?;
 
-    let task_monitor = TaskMonitor::new(app.clone(), shutdown.clone());
-
-    // Process to push new identities to Ethereum
-    task_monitor.start().await;
+    TaskMonitor::init(app.clone(), shutdown.clone()).await;
 
     // Start server (will stop on shutdown signal)
     server::run(app, server_config, shutdown.clone()).await?;
 
-    tracing::info!("Stopping the app");
-    task_monitor.shutdown().await?;
+    // If server::run returns, we can shutdown the rest of the app
+    tracing::info!("Shutting down");
+    shutdown.shutdown();
 
     Ok(())
 }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -63,7 +63,7 @@ impl Shutdown {
 
     /// Wait for the shutdown to begin.
     ///
-    /// If the caller down not already own a `Receiver`
+    /// If the caller does not already own a `Receiver`
     /// then the process may abort immediately when this returns.
     pub async fn await_shutdown_begin(&self) {
         let _ = self.await_shutdown_begin_with_handle().await;

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,66 +1,116 @@
-use std::future::Future;
-use std::sync::Arc;
+use std::time::Duration;
 
 use eyre::Result;
+use tokio::select;
 use tokio::sync::watch::{self, Receiver, Sender};
-use tracing::info;
+use tracing::{error, info};
 
+/// A watch channel used to syncronize tasks to shutdown.
+#[derive(Clone)]
 pub struct Shutdown {
     sender: Sender<bool>,
-    receiver: Receiver<bool>,
 }
 
 impl Shutdown {
-    pub fn new() -> Self {
-        let (sender, receiver) = watch::channel(false);
-        Self { sender, receiver }
+    /// Create a new shutdown and spawn a task to monitor it.
+    ///
+    /// * `timeout` - The maximum time to wait for all receivers to be dropped.
+    ///               If all receivers have not been dropped by the timout the
+    ///               process will exit with code 1.
+    ///
+    /// * `delay` - A minimum delay before calling [`std::process::exit`]. This us useful to allow
+    ///             for cancaled futures to make it to an await point.
+    ///
+    /// Shutdown can be triggered by calling [`Shutdown::shutdown`].
+    /// The shutdown will begin immediately after the delay expires if no receivers
+    /// are being held.
+    pub fn spawn(timeout: Duration, delay: Duration) -> Self {
+        let (sender, _) = watch::channel(false);
+        let shutdown = Self { sender };
+        shutdown.clone().spawn_monitor(timeout, delay);
+        shutdown
     }
 
     /// Send the signal to shutdown the program.
     pub fn shutdown(&self) {
-        // Does not fail because the channel never closes.
-        self.sender.send(true).unwrap();
+        self.sender.send(true).ok();
     }
 
     /// Are we currently shutting down?
     #[must_use]
     pub fn is_shutting_down(&self) -> bool {
-        *self.receiver.borrow()
+        *self.sender.subscribe().borrow()
     }
 
-    /// Wait for the program to shutdown.
+    /// Returns a `Receiver` which must be held until the caller is ready to shutdown.
+    #[must_use]
+    pub fn handle(&self) -> Receiver<bool> {
+        self.sender.subscribe()
+    }
+
+    /// Wait for the shutdown to begin.
     ///
-    /// Resolves immediately if the program is already shutting down.
-    /// The resulting future is safe to cancel by dropping.
-    pub fn await_shutdown(&self) -> impl Future<Output = ()> + 'static {
-        let mut watch = self.receiver.clone();
+    /// Returns a `Receiver` which must be held until the caller is ready to shutdown.
+    #[must_use]
+    pub async fn await_shutdown_begin_with_handle(&self) -> Receiver<bool> {
+        let mut receiver = self.sender.subscribe();
+        if *receiver.borrow_and_update() {
+            return receiver;
+        }
+        receiver.changed().await.ok();
+        receiver
+    }
 
-        async move {
-            if *watch.borrow_and_update() {
-                return;
+    /// Wait for the shutdown to begin.
+    ///
+    /// If the caller down not already own a `Receiver`
+    /// then the process may abort immediately when this returns.
+    pub async fn await_shutdown_begin(&self) {
+        let _ = self.await_shutdown_begin_with_handle().await;
+    }
+
+    /// Wait for the channel to be closed, signaling that all receivers have been dropped.
+    pub async fn await_shutdown_complete(&self) {
+        self.sender.closed().await;
+    }
+
+    /// Return the number of receivers still active.
+    pub async fn receiver_count(&self) -> usize {
+        self.sender.receiver_count()
+    }
+
+    /// Spawn a task that will monitor the shutdown signal.
+    ///
+    /// This should only be called once.
+    /// Will force a shutdown with `std::process::exit(1)` if shutdown takes to long.
+    /// Otherwise will exit with code 0.
+    fn spawn_monitor(self, timeout: Duration, delay: Duration) {
+        tokio::spawn(async move {
+            select! {
+                _ = self.await_shutdown_begin() => {
+                    info!("shutdown monitor shutdown received");
+                },
+                _ = signal_shutdown() => {
+                    self.shutdown();
+                    info!("Shutdown signal received, shutting down");
+                }
             }
-            // Does not fail because the channel never closes test_config.
-            watch.changed().await.unwrap();
-        }
-    }
-}
 
-impl Default for Shutdown {
-    fn default() -> Self {
-        Self::new()
+            let start = tokio::time::Instant::now();
+            tokio::time::sleep(delay).await;
+            select! {
+                _ = self.await_shutdown_complete() => {
+                    let elapsed = start.elapsed();
+                    info!("shutdown channel closed, gracefully shut down in {:?}", elapsed);
+                    std::process::exit(0);
+                },
+                _ = tokio::time::sleep(timeout) => {
+                    error!("shutdown monitor timed out");
+                    std::process::exit(1);
+                }
+            }
+        });
     }
-}
-
-pub fn watch_shutdown_signals(shutdown: Arc<Shutdown>) {
-    tokio::spawn({
-        async move {
-            signal_shutdown()
-                .await
-                .map_err(|err| tracing::error!("Error handling Ctrl-C: {}", err))
-                .unwrap();
-            shutdown.shutdown();
-        }
-    });
 }
 
 #[cfg(unix)]
@@ -97,7 +147,7 @@ mod tests {
     async fn shutdown_signal() {
         let start = tokio::time::Instant::now();
 
-        let shutdown = Arc::new(Shutdown::new());
+        let shutdown = Shutdown::spawn(Duration::from_secs(30), Duration::from_secs(1));
 
         let shutdown_clone = shutdown.clone();
         tokio::spawn(async move {
@@ -105,7 +155,7 @@ mod tests {
             shutdown_clone.shutdown();
         });
 
-        shutdown.await_shutdown().await;
+        shutdown.await_shutdown_begin().await;
 
         let elapsed = start.elapsed();
 

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -82,7 +82,7 @@ impl Shutdown {
     /// Spawn a task that will monitor the shutdown signal.
     ///
     /// This should only be called once.
-    /// Will force a shutdown with `std::process::exit(1)` if shutdown takes to long.
+    /// Will force a shutdown with `std::process::exit(1)` if shutdown takes too long.
     /// Otherwise will exit with code 0.
     fn spawn_monitor(self, timeout: Duration, delay: Duration) {
         tokio::spawn(async move {

--- a/src/task_monitor/mod.rs
+++ b/src/task_monitor/mod.rs
@@ -1,11 +1,14 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use once_cell::sync::Lazy;
 use prometheus::{linear_buckets, register_gauge, register_histogram, Gauge, Histogram};
-use tokio::sync::{broadcast, mpsc, Mutex, Notify, RwLock};
+use tokio::select;
+use tokio::sync::{mpsc, Mutex, Notify};
 use tokio::task::JoinHandle;
-use tracing::{info, instrument, warn};
+use tracing::{error, info, instrument, warn};
 
 use crate::app::App;
 use crate::database::methods::DbMethods as _;
@@ -20,11 +23,6 @@ const FINALIZE_IDENTITIES_BACKOFF: Duration = Duration::from_secs(5);
 const QUEUE_MONITOR_BACKOFF: Duration = Duration::from_secs(5);
 const INSERT_IDENTITIES_BACKOFF: Duration = Duration::from_secs(5);
 const DELETE_IDENTITIES_BACKOFF: Duration = Duration::from_secs(5);
-
-struct RunningInstance {
-    handles: Vec<JoinHandle<()>>,
-    shutdown_sender: broadcast::Sender<()>,
-}
 
 static PENDING_IDENTITIES: Lazy<Gauge> = Lazy::new(|| {
     register_gauge!("pending_identities", "Identities not submitted on-chain").unwrap()
@@ -47,62 +45,19 @@ static BATCH_SIZES: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
-impl RunningInstance {
-    async fn shutdown(self) -> anyhow::Result<()> {
-        info!("Sending a shutdown signal to the committer.");
-        // Ignoring errors here, since we have two options: either the channel is full,
-        // which is impossible, since this is the only use, and this method takes
-        // ownership, or the channel is closed, which means the committer thread is
-        // already dead.
-        _ = self.shutdown_sender.send(());
-
-        info!("Awaiting tasks to shutdown.");
-        for result in futures::future::join_all(self.handles).await {
-            result?;
-        }
-
-        Ok(())
-    }
-}
-
-/// A worker that commits identities to the blockchain.
+/// A task manager for all long running tasks
 ///
-/// This uses the database to keep track of identities that need to be
-/// committed. It assumes that there's only one such worker spawned at
-/// a time. Spawning multiple worker threads will result in undefined behavior,
+/// It's assumed that there is only one instance at a time.
+/// Spawning multiple `TaskManagers` will result in undefined behavior,
 /// including data duplication.
-pub struct TaskMonitor {
-    /// The instance is kept behind an RwLock<Option<...>> because
-    /// when shutdown is called we want to be able to gracefully
-    /// await the join handles - which requires ownership of the handle and by
-    /// extension the instance.
-    instance: RwLock<Option<RunningInstance>>,
-    shutdown: Arc<Shutdown>,
-    app: Arc<App>,
-}
+pub struct TaskMonitor;
 
 impl TaskMonitor {
-    pub fn new(app: Arc<App>, shutdown: Arc<Shutdown>) -> Self {
-        Self {
-            instance: RwLock::new(None),
-            shutdown,
-            app,
-        }
-    }
-
+    /// Initialize and run the task monitor
     #[instrument(level = "debug", skip_all)]
-    pub async fn start(&self) {
-        let mut instance = self.instance.write().await;
-        if instance.is_some() {
-            warn!("Identity committer already running");
-        }
-
-        // We could use the second element of the tuple as `mut shutdown_receiver`,
-        // but for symmetry's sake we create it for every task with `.subscribe()`
-        let (shutdown_sender, _) = broadcast::channel(1);
-
+    pub async fn init(main_app: Arc<App>, shutdown: Shutdown) {
         let (monitored_txs_sender, monitored_txs_receiver) =
-            mpsc::channel(self.app.config.app.monitored_txs_capacity);
+            mpsc::channel(main_app.clone().config.app.monitored_txs_capacity);
 
         let monitored_txs_sender = Arc::new(monitored_txs_sender);
         let monitored_txs_receiver = Arc::new(Mutex::new(monitored_txs_receiver));
@@ -112,39 +67,36 @@ impl TaskMonitor {
         // in the database
         base_wake_up_notify.notify_one();
 
-        let mut handles = Vec::new();
+        let handles = FuturesUnordered::new();
 
         // Initialize the Tree
-        let app = self.app.clone();
+        let app = main_app.clone();
         let tree_init = move || app.clone().init_tree();
-        let tree_init_handle = crate::utils::spawn_monitored_with_backoff(
+        let tree_init_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
             tree_init,
-            shutdown_sender.clone(),
             TREE_INIT_BACKOFF,
-            self.shutdown.clone(),
+            shutdown.clone(),
         );
 
         handles.push(tree_init_handle);
 
         // Finalize identities
-        let app = self.app.clone();
+        let app = main_app.clone();
         let finalize_identities = move || tasks::finalize_identities::finalize_roots(app.clone());
-        let finalize_identities_handle = crate::utils::spawn_monitored_with_backoff(
+        let finalize_identities_handle = crate::utils::spawn_with_backoff(
             finalize_identities,
-            shutdown_sender.clone(),
             FINALIZE_IDENTITIES_BACKOFF,
-            self.shutdown.clone(),
+            shutdown.clone(),
         );
         handles.push(finalize_identities_handle);
 
         // Report length of the queue of identities
-        let app = self.app.clone();
+        let app = main_app.clone();
         let queue_monitor = move || tasks::monitor_queue::monitor_queue(app.clone());
-        let queue_monitor_handle = crate::utils::spawn_monitored_with_backoff(
+        let queue_monitor_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
             queue_monitor,
-            shutdown_sender.clone(),
             QUEUE_MONITOR_BACKOFF,
-            self.shutdown.clone(),
+            shutdown.clone(),
         );
         handles.push(queue_monitor_handle);
 
@@ -152,7 +104,7 @@ impl TaskMonitor {
         let base_next_batch_notify = Arc::new(Notify::new());
 
         // Create batches
-        let app = self.app.clone();
+        let app = main_app.clone();
         let next_batch_notify = base_next_batch_notify.clone();
         let wake_up_notify = base_wake_up_notify.clone();
 
@@ -163,16 +115,15 @@ impl TaskMonitor {
                 wake_up_notify.clone(),
             )
         };
-        let create_batches_handle = crate::utils::spawn_monitored_with_backoff(
+        let create_batches_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
             create_batches,
-            shutdown_sender.clone(),
             PROCESS_IDENTITIES_BACKOFF,
-            self.shutdown.clone(),
+            shutdown.clone(),
         );
         handles.push(create_batches_handle);
 
         // Process batches
-        let app = self.app.clone();
+        let app = main_app.clone();
         let next_batch_notify = base_next_batch_notify.clone();
         let wake_up_notify = base_wake_up_notify.clone();
 
@@ -184,30 +135,28 @@ impl TaskMonitor {
                 wake_up_notify.clone(),
             )
         };
-        let process_identities_handle = crate::utils::spawn_monitored_with_backoff(
+        let process_identities_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
             process_identities,
-            shutdown_sender.clone(),
             PROCESS_IDENTITIES_BACKOFF,
-            self.shutdown.clone(),
+            shutdown.clone(),
         );
         handles.push(process_identities_handle);
 
         // Monitor transactions
-        let app = self.app.clone();
+        let app = main_app.clone();
         let monitor_txs =
             move || tasks::monitor_txs::monitor_txs(app.clone(), monitored_txs_receiver.clone());
-        let monitor_txs_handle = crate::utils::spawn_monitored_with_backoff(
+        let monitor_txs_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
             monitor_txs,
-            shutdown_sender.clone(),
             PROCESS_IDENTITIES_BACKOFF,
-            self.shutdown.clone(),
+            shutdown.clone(),
         );
         handles.push(monitor_txs_handle);
 
         let pending_insertion_mutex = Arc::new(Mutex::new(()));
 
         // Insert identities
-        let app = self.app.clone();
+        let app = main_app.clone();
         let wake_up_notify = base_wake_up_notify.clone();
         let insertion_mutex = pending_insertion_mutex.clone();
         let insert_identities = move || {
@@ -218,16 +167,15 @@ impl TaskMonitor {
             )
         };
 
-        let insert_identities_handle = crate::utils::spawn_monitored_with_backoff(
+        let insert_identities_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
             insert_identities,
-            shutdown_sender.clone(),
             INSERT_IDENTITIES_BACKOFF,
-            self.shutdown.clone(),
+            shutdown.clone(),
         );
         handles.push(insert_identities_handle);
 
         // Delete identities
-        let app = self.app.clone();
+        let app = main_app.clone();
         let wake_up_notify = base_wake_up_notify.clone();
         let delete_identities = move || {
             self::tasks::delete_identities::delete_identities(
@@ -237,19 +185,43 @@ impl TaskMonitor {
             )
         };
 
-        let delete_identities_handle = crate::utils::spawn_monitored_with_backoff(
+        let delete_identities_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
             delete_identities,
-            shutdown_sender.clone(),
             DELETE_IDENTITIES_BACKOFF,
-            self.shutdown.clone(),
+            shutdown.clone(),
         );
         handles.push(delete_identities_handle);
 
-        // Create the instance
-        *instance = Some(RunningInstance {
-            handles,
-            shutdown_sender,
-        });
+        tokio::spawn(Self::monitor_shutdown(handles, shutdown.clone()));
+    }
+
+    async fn monitor_shutdown(mut handles: FuturesUnordered<JoinHandle<()>>, shutdown: Shutdown) {
+        select! {
+            // Wait for the shutdown signal
+            _ = shutdown.await_shutdown_begin() => {
+             }
+            // Or wait for a task to panic
+            _ = Self::await_task_panic(&mut handles, shutdown.clone()) => {}
+        };
+    }
+
+    async fn await_task_panic(handles: &mut FuturesUnordered<JoinHandle<()>>, shutdown: Shutdown) {
+        while let Some(result) = handles.next().await {
+            if !shutdown.is_shutting_down() {
+                match result {
+                    Ok(_) => {
+                        info!("task exited");
+                    }
+                    Err(error) => {
+                        error!(?error, "task panicked");
+                        // Instruct the rest of the app to shutdown
+                        shutdown.clone().shutdown();
+                        return;
+                    }
+                }
+            }
+        }
+        warn!("all tasks have returned unexpectedly");
     }
 
     async fn log_pending_identities_count(database: &Database) -> anyhow::Result<()> {
@@ -273,19 +245,5 @@ impl TaskMonitor {
     #[allow(clippy::cast_precision_loss)]
     fn log_batch_size(size: usize) {
         BATCH_SIZES.observe(size as f64);
-    }
-
-    /// # Errors
-    ///
-    /// Will return an Error if the committer thread cannot be shut down
-    /// gracefully.
-    pub async fn shutdown(&self) -> anyhow::Result<()> {
-        let mut instance = self.instance.write().await;
-        if let Some(instance) = instance.take() {
-            instance.shutdown().await?;
-        } else {
-            info!("Committer not running.");
-        }
-        Ok(())
     }
 }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -25,6 +25,10 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 [policy."ethers-core:2.0.14@git:6e2ff0ef8af8c0ee3c21b7e1960f8c025bcd5588"]
 audit-as-crates-io = true
 
+[[exemptions.tower-http]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.Inflector]]
 version = "0.11.4"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -25,10 +25,6 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 [policy."ethers-core:2.0.14@git:6e2ff0ef8af8c0ee3c21b7e1960f8c025bcd5588"]
 audit-as-crates-io = true
 
-[[exemptions.tower-http]]
-version = "0.6.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.Inflector]]
 version = "0.11.4"
 criteria = "safe-to-deploy"
@@ -1751,6 +1747,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tower]]
 version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.tower-http]]
+version = "0.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tower-layer]]

--- a/tests/common/test_config.rs
+++ b/tests/common/test_config.rs
@@ -18,6 +18,8 @@ pub const DEFAULT_BATCH_DELETION_TIMEOUT_SECONDS: u64 = 10;
 pub const DEFAULT_TREE_DEPTH: usize = 20;
 pub const DEFAULT_TREE_DENSE_PREFIX_DEPTH: usize = 10;
 pub const DEFAULT_TIME_BETWEEN_SCANS_SECONDS: u64 = 1;
+pub const DEFAULT_SHUTDOWN_TIMEOUT_SECONDS: u64 = 5;
+pub const DEFAULT_SHUTDOWN_DELAY_SECONDS: u64 = 1;
 
 pub struct TestConfigBuilder {
     tree_depth: usize,
@@ -25,6 +27,8 @@ pub struct TestConfigBuilder {
     prover_urls: Vec<ProverConfig>,
     batch_insertion_timeout: Duration,
     batch_deletion_timeout: Duration,
+    shutdown_timeout: Duration,
+    shutdown_delay: Duration,
     min_batch_deletion_size: usize,
     db_url: Option<String>,
     oz_api_url: Option<String>,
@@ -43,6 +47,8 @@ impl TestConfigBuilder {
             prover_urls: vec![],
             batch_insertion_timeout: Duration::from_secs(DEFAULT_BATCH_INSERTION_TIMEOUT_SECONDS),
             batch_deletion_timeout: Duration::from_secs(DEFAULT_BATCH_DELETION_TIMEOUT_SECONDS),
+            shutdown_timeout: Duration::from_secs(DEFAULT_SHUTDOWN_TIMEOUT_SECONDS),
+            shutdown_delay: Duration::from_secs(DEFAULT_SHUTDOWN_DELAY_SECONDS),
             min_batch_deletion_size: 1,
             db_url: None,
             oz_api_url: None,
@@ -148,6 +154,8 @@ impl TestConfigBuilder {
                 scanning_chain_head_offset: default::scanning_chain_head_offset(),
                 time_between_scans: Duration::from_secs(DEFAULT_TIME_BETWEEN_SCANS_SECONDS),
                 monitored_txs_capacity: default::monitored_txs_capacity(),
+                shutdown_timeout: self.shutdown_timeout,
+                shutdown_delay: self.shutdown_delay,
             },
             tree: TreeConfig {
                 tree_depth: self.tree_depth,

--- a/tests/graceful_shutdown.rs
+++ b/tests/graceful_shutdown.rs
@@ -1,0 +1,69 @@
+#![allow(clippy::needless_range_loop)]
+
+mod common;
+
+use common::prelude::*;
+
+const IDLE_TIME: u64 = 5;
+
+#[tokio::test]
+async fn graceful_shutdown_test() -> anyhow::Result<()> {
+    graceful_shutdown(false).await
+}
+
+async fn graceful_shutdown(offchain_mode_enabled: bool) -> anyhow::Result<()> {
+    // Initialize logging for the test.
+    init_tracing_subscriber();
+    info!("Starting integration test");
+
+    let insertion_batch_size: usize = 8;
+    let deletion_batch_size: usize = 3;
+
+    let ref_tree = PoseidonTree::new(DEFAULT_TREE_DEPTH + 1, ruint::Uint::ZERO);
+    let initial_root: U256 = ref_tree.root().into();
+
+    let docker = Cli::default();
+    let (mock_chain, db_container, insertion_prover_map, deletion_prover_map, micro_oz) =
+        spawn_deps(
+            initial_root,
+            &[insertion_batch_size],
+            &[deletion_batch_size],
+            DEFAULT_TREE_DEPTH as u8,
+            &docker,
+        )
+        .await?;
+
+    let mock_insertion_prover = &insertion_prover_map[&insertion_batch_size];
+    let mock_deletion_prover = &deletion_prover_map[&deletion_batch_size];
+
+    let db_socket_addr = db_container.address();
+    let db_url = format!("postgres://postgres:postgres@{db_socket_addr}/database");
+
+    let temp_dir = tempfile::tempdir()?;
+    info!(
+        "temp dir created at: {:?}",
+        temp_dir.path().join("testfile")
+    );
+
+    let config = TestConfigBuilder::new()
+        .db_url(&db_url)
+        .oz_api_url(&micro_oz.endpoint())
+        .oz_address(micro_oz.address())
+        .identity_manager_address(mock_chain.identity_manager.address())
+        .primary_network_provider(mock_chain.anvil.endpoint())
+        .cache_file(temp_dir.path().join("testfile").to_str().unwrap())
+        .add_prover(mock_insertion_prover)
+        .add_prover(mock_deletion_prover)
+        .offchain_mode(offchain_mode_enabled)
+        .build()?;
+
+    let (_, _app_handle, _local_addr, shutdown) = spawn_app(config.clone())
+        .await
+        .expect("Failed to spawn app.");
+
+    tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
+    shutdown.shutdown();
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    panic!("error: process took longer than 5 seconds to shutdown");
+}


### PR DESCRIPTION
## Motivation

Currently we've been running with `panic="abort"` which is known to cause problems with our mmap caching system.

## Solution

I've overhauled the shutdown system that we've been using to 
- make it more ergonomic
- make it more functional
- allow for graceful shutdowns through `std::process::exit`

There are now 2 ways we can shutdown long running tasks
1. - Cancel the future they're running on.
        - Allows tasks to continue for a short delay period until they hit an `await` point and stall.
        - This should work for 99% of cases
2. - Provide the task with it's own `Shutdown` instance and allow it some short period (30s default) to clean itself up.

Since all panics used to abort, It's possible we may have been relying on that behaviour in some places I haven't noticed. Instead now we should prefer issuing a `shutdown`.

For this reason, I've installed a `PanicHandler` layer in the server to catch panics then issue a global shutdown. I'm not actually sure this is what we want so I'm happy to remove it if that's the case.

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
