### PR TITLE
Update `get_proof_for()`to fetch `TreeVersion` by item status

### DIFF
--- a/src/identity/processor.rs
+++ b/src/identity/processor.rs
@@ -259,7 +259,7 @@ impl OnChainIdentityProcessor {
             )
             .await
             .map_err(|e| {
-                error!(?e, "Failed to insert identity to contract.");
+                error!(?e, "Failed to insert identity  to contract.");
                 e
             })?;
 

--- a/src/identity_tree/mod.rs
+++ b/src/identity_tree/mod.rs
@@ -585,7 +585,12 @@ impl TreeState {
 
     #[must_use]
     pub fn get_proof_for(&self, item: &TreeItem) -> (Field, InclusionProof) {
-        let (leaf, root, proof) = self.latest.get_leaf_and_proof(item.leaf_index);
+        let (leaf, root, proof) = match item.status {
+            ProcessedStatus::Processed | ProcessedStatus::Mined => {
+                self.processed.get_leaf_and_proof(item.leaf_index)
+            }
+            ProcessedStatus::Pending => self.latest.get_leaf_and_proof(item.leaf_index),
+        };
 
         let proof = InclusionProof {
             root: Some(root),


### PR DESCRIPTION
Currently when fetching an inclusion proof for a given `TreeItem`, the latest tree is used regardless of item status.


```rust
    pub fn get_proof_for(&self, item: &TreeItem) -> (Field, InclusionProof) {
        let (leaf, root, proof) = self.latest.get_leaf_and_proof(item.leaf_index);

        let proof = InclusionProof {
            root: Some(root),
            proof: Some(proof),
            message: None,
        };

        (leaf, proof)
    }
```

This PR introduces logic to serve inclusion proofs based on item status.

```rust
    pub fn get_proof_for(&self, item: &TreeItem) -> (Field, InclusionProof) {
        let (leaf, root, proof) = match item.status {
            ProcessedStatus::Processed | ProcessedStatus::Mined => {
                self.processed.get_leaf_and_proof(item.leaf_index)
            }
            ProcessedStatus::Pending => self.latest.get_leaf_and_proof(item.leaf_index),
        };

        let proof = InclusionProof {
            root: Some(root),
            proof: Some(proof),
            message: None,
        };

        (leaf, proof)
    }
```