### PR TITLE
Skip ticks when missed.

### DIFF
--- a/src/task_monitor/tasks/create_batches.rs
+++ b/src/task_monitor/tasks/create_batches.rs
@@ -7,6 +7,7 @@ use semaphore::poseidon_tree::{Branch, PoseidonHash};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
+use tokio::time::MissedTickBehavior;
 use tokio::{select, time};
 use tracing::instrument;
 
@@ -40,7 +41,7 @@ pub async fn create_batches(
     // We start a timer and force it to perform one initial tick to avoid an
     // immediate trigger.
     let mut timer = time::interval(Duration::from_secs(5));
-    timer.tick().await;
+    timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     // When both futures are woken at once, the choice is made
     // non-deterministically. This could, in the worst case, result in users waiting

--- a/src/task_monitor/tasks/delete_identities.rs
+++ b/src/task_monitor/tasks/delete_identities.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::Context;
 use chrono::Utc;
 use tokio::sync::{Mutex, Notify};
+use tokio::time::MissedTickBehavior;
 use tokio::{select, time};
 use tracing::info;
 
@@ -30,6 +31,7 @@ pub async fn delete_identities(
         .context("Invalid batch deletion timeout duration")?;
 
     let mut timer = time::interval(Duration::from_secs(5));
+    timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
         select! {

--- a/src/task_monitor/tasks/insert_identities.rs
+++ b/src/task_monitor/tasks/insert_identities.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::{Mutex, Notify};
+use tokio::time::MissedTickBehavior;
 use tokio::{select, time};
 use tracing::info;
 
@@ -23,6 +24,7 @@ pub async fn insert_identities(
     info!("Starting insertion processor task.");
 
     let mut timer = time::interval(Duration::from_secs(5));
+    timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
         select! {

--- a/src/task_monitor/tasks/process_batches.rs
+++ b/src/task_monitor/tasks/process_batches.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::{mpsc, Notify};
-use tokio::{select, time};
-
 use crate::app::App;
 use crate::database::methods::DbMethods as _;
 use crate::identity::processor::TransactionId;
+use tokio::sync::{mpsc, Notify};
+use tokio::time::MissedTickBehavior;
+use tokio::{select, time};
 
 pub async fn process_batches(
     app: Arc<App>,
@@ -23,6 +23,7 @@ pub async fn process_batches(
     tracing::info!("Starting identity processor.");
 
     let mut timer = time::interval(Duration::from_secs(5));
+    timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
         // We wait either for a timer tick or a full batch


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

When for some reason (like tree rebuild or similar) tasks wait long for something, ticks are being buffered if time passes. It then results in multiple "ticks" same time when. When skip strategy is used then ticks are not buffered.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
