### PR TITLE
Make tree initialization sync process again.

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -957,7 +957,7 @@ mod test {
             .await
             .context("Marking root as mined")?;
 
-        let root_2_mined_at = Utc::now();
+        let root_0_mined_at = Utc::now();
 
         tokio::time::sleep(Duration::from_secs(2)).await; // sleep enough for the database time resolution
 
@@ -968,12 +968,12 @@ mod test {
         let root_item_1 = db.get_root_state(&roots[1]).await?.unwrap();
         assert_eq!(root_item_1.status, ProcessedStatus::Pending);
         assert!(root_item_1.mined_valid_as_of.is_none());
-        assert!(root_item_1.pending_valid_as_of < root_2_mined_at);
+        assert!(root_item_1.pending_valid_as_of < root_0_mined_at);
 
         let root_item_0 = db.get_root_state(&roots[0]).await?.unwrap();
         assert!(root_item_0.pending_valid_as_of < root_1_inserted_at);
         assert_eq!(root_item_0.status, ProcessedStatus::Processed);
-        assert!(root_item_0.mined_valid_as_of.unwrap() < root_2_mined_at);
+        assert_same_time!(root_item_0.mined_valid_as_of.unwrap(), root_0_mined_at);
         assert!(root_item_0.mined_valid_as_of.unwrap() > root_1_inserted_at);
         assert!(root_item_0.pending_valid_as_of < root_1_inserted_at);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ async fn sequencer_app(args: Args) -> anyhow::Result<()> {
     // Create App struct
     let app = App::new(config).await?;
 
-    TaskMonitor::init(app.clone(), shutdown.clone()).await;
+    TaskMonitor::init(app.clone(), shutdown.clone()).await?;
 
     // Start server (will stop on shutdown signal)
     server::run(app, server_config, shutdown.clone()).await?;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -645,7 +645,7 @@ pub async fn spawn_app_returning_initialized_tree(
     let app = App::new(config).await.expect("Failed to create App");
     let shutdown = Shutdown::spawn(Duration::from_secs(30), Duration::from_secs(1));
 
-    TaskMonitor::init(app.clone(), shutdown.clone()).await;
+    TaskMonitor::init(app.clone(), shutdown.clone()).await?;
 
     let listener = TcpListener::bind(server_config.address)
         .await


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

While tree is being initialized part of the endpoints return 5xx responses. To easily be able to not route traffic to such instance when running multiple in HA mode we can make tree intialization sync again. This way metrics server that is treated as healthcheck won't start before tree is initalized.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
