### PR TITLE
Remove batches correction. Add name for tasks for easier debugging.

### DIFF
--- a/src/database/methods.rs
+++ b/src/database/methods.rs
@@ -870,38 +870,6 @@ pub trait DbMethods<'c>: Acquire<'c, Database = Postgres> + Sized {
     }
 
     #[instrument(skip(self), level = "debug")]
-    async fn delete_batches_after_root(self, root: &Hash) -> Result<(), Error> {
-        let mut conn = self.acquire().await?;
-
-        sqlx::query(
-            r#"
-            DELETE FROM batches
-            WHERE prev_root = $1
-            "#,
-        )
-        .bind(root)
-        .execute(&mut *conn)
-        .await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip(self), level = "debug")]
-    async fn delete_all_batches(self) -> Result<(), Error> {
-        let mut conn = self.acquire().await?;
-
-        sqlx::query(
-            r#"
-            DELETE FROM batches
-            "#,
-        )
-        .execute(&mut *conn)
-        .await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip(self), level = "debug")]
     async fn insert_new_transaction(
         self,
         transaction_id: &String,

--- a/src/ethereum/mod.rs
+++ b/src/ethereum/mod.rs
@@ -86,10 +86,6 @@ impl Ethereum {
             .await
     }
 
-    pub async fn fetch_pending_transactions(&self) -> Result<Vec<TransactionId>, TxError> {
-        self.write_provider.fetch_pending_transactions().await
-    }
-
     pub async fn mine_transaction(&self, tx: TransactionId) -> Result<bool, TxError> {
         self.write_provider.mine_transaction(tx).await
     }

--- a/src/ethereum/write_provider/inner.rs
+++ b/src/ethereum/write_provider/inner.rs
@@ -13,8 +13,6 @@ pub trait Inner: Send + Sync + 'static {
         tx_id: Option<String>,
     ) -> Result<TransactionId, TxError>;
 
-    async fn fetch_pending_transactions(&self) -> Result<Vec<TransactionId>, TxError>;
-
     async fn mine_transaction(&self, tx: TransactionId) -> Result<TransactionResult, TxError>;
 }
 

--- a/src/ethereum/write_provider/mod.rs
+++ b/src/ethereum/write_provider/mod.rs
@@ -65,10 +65,6 @@ impl WriteProvider {
         self.inner.send_transaction(tx, only_once, tx_id).await
     }
 
-    pub async fn fetch_pending_transactions(&self) -> Result<Vec<TransactionId>, TxError> {
-        self.inner.fetch_pending_transactions().await
-    }
-
     pub async fn mine_transaction(&self, tx: TransactionId) -> Result<bool, TxError> {
         let oz_transaction_result = self.inner.mine_transaction(tx.clone()).await;
 

--- a/src/ethereum/write_provider/openzeppelin.rs
+++ b/src/ethereum/write_provider/openzeppelin.rs
@@ -201,20 +201,6 @@ impl OzRelay {
     ) -> Result<RelayerTransactionBase, TxError> {
         self.mine_transaction_id(tx_id.as_str()).await
     }
-
-    pub async fn fetch_pending_transactions(&self) -> Result<Vec<TransactionId>, TxError> {
-        let recent_pending_txs = self
-            .list_recent_transactions()
-            .await
-            .map_err(|err| TxError::Fetch(Box::new(err)))?;
-
-        let pending_txs = recent_pending_txs
-            .into_iter()
-            .map(|tx| tx.transaction_id)
-            .collect();
-
-        Ok(pending_txs)
-    }
 }
 
 #[async_trait::async_trait]
@@ -226,10 +212,6 @@ impl Inner for OzRelay {
         tx_id: Option<String>,
     ) -> Result<TransactionId, TxError> {
         self.send_transaction(tx, only_once, tx_id).await
-    }
-
-    async fn fetch_pending_transactions(&self) -> Result<Vec<TransactionId>, TxError> {
-        self.fetch_pending_transactions().await
     }
 
     async fn mine_transaction(&self, tx: TransactionId) -> Result<TransactionResult, TxError> {

--- a/src/ethereum/write_provider/tx_sitter.rs
+++ b/src/ethereum/write_provider/tx_sitter.rs
@@ -107,30 +107,6 @@ impl Inner for TxSitter {
         Ok(tx.tx_id)
     }
 
-    async fn fetch_pending_transactions(&self) -> Result<Vec<TransactionId>, TxError> {
-        let unsent_txs = self
-            .client
-            .get_unsent_txs()
-            .await
-            .context("Error fetching unsent transactions")
-            .map_err(TxError::Send)?;
-
-        let pending_txs = self
-            .client
-            .get_txs_by_status(TxStatus::Pending)
-            .await
-            .context("Error fetching pending transactions")
-            .map_err(TxError::Send)?;
-
-        let mut tx_ids = vec![];
-
-        for tx in unsent_txs.into_iter().chain(pending_txs) {
-            tx_ids.push(tx.tx_id);
-        }
-
-        Ok(tx_ids)
-    }
-
     async fn mine_transaction(&self, tx: TransactionId) -> Result<TransactionResult, TxError> {
         tokio::time::timeout(MINING_TIMEOUT, self.mine_transaction_inner(tx))
             .await

--- a/src/identity_tree/initializer.rs
+++ b/src/identity_tree/initializer.rs
@@ -36,9 +36,6 @@ impl TreeInitializer {
     /// Initializes the tree state. This should only ever be called once.
     /// Attempts to call this method more than once will result in a panic.
     pub async fn run(self) -> anyhow::Result<TreeState> {
-        // Await for all pending transactions
-        self.identity_processor.await_clean_slate().await?;
-
         let initial_root_hash =
             LazyPoseidonTree::new(self.config.tree_depth, self.config.initial_leaf_value).root();
 

--- a/src/task_monitor/mod.rs
+++ b/src/task_monitor/mod.rs
@@ -64,6 +64,7 @@ impl TaskMonitor {
             tasks::finalize_identities::finalize_roots(app.clone(), sync_tree_notify.clone())
         };
         let finalize_identities_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
+            "finalize_identities".to_string(),
             finalize_identities,
             FINALIZE_IDENTITIES_BACKOFF,
             shutdown.clone(),
@@ -74,6 +75,7 @@ impl TaskMonitor {
         let app = main_app.clone();
         let queue_monitor = move || tasks::monitor_queue::monitor_queue(app.clone());
         let queue_monitor_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
+            "queue_monitor".to_string(),
             queue_monitor,
             QUEUE_MONITOR_BACKOFF,
             shutdown.clone(),
@@ -95,6 +97,7 @@ impl TaskMonitor {
             )
         };
         let create_batches_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
+            "create_batches".to_string(),
             create_batches,
             CREATE_BATCHES_BACKOFF,
             shutdown.clone(),
@@ -113,6 +116,7 @@ impl TaskMonitor {
             )
         };
         let process_batches_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
+            "process_batches".to_string(),
             process_batches,
             PROCESS_BATCHES_BACKOFF,
             shutdown.clone(),
@@ -124,6 +128,7 @@ impl TaskMonitor {
         let monitor_txs =
             move || tasks::monitor_txs::monitor_txs(app.clone(), monitored_txs_receiver.clone());
         let monitor_txs_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
+            "monitor_txs".to_string(),
             monitor_txs,
             MONITOR_TXS_BACKOFF,
             shutdown.clone(),
@@ -143,6 +148,7 @@ impl TaskMonitor {
             )
         };
         let modify_tree_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
+            "modify_tree".to_string(),
             modify_tree,
             MODIFY_TREE_BACKOFF,
             shutdown.clone(),
@@ -162,6 +168,7 @@ impl TaskMonitor {
             )
         };
         let sync_tree_state_with_db_handle = crate::utils::spawn_with_backoff_cancel_on_shutdown(
+            "sync_tree_state_with_db".to_string(),
             sync_tree_state_with_db,
             SYNC_TREE_STATE_WITH_DB_BACKOFF,
             shutdown.clone(),

--- a/src/task_monitor/tasks/create_batches.rs
+++ b/src/task_monitor/tasks/create_batches.rs
@@ -35,12 +35,6 @@ pub async fn create_batches(
     sync_tree_notify: Arc<Notify>,
     mut tree_synced_rx: Receiver<()>,
 ) -> anyhow::Result<()> {
-    tracing::info!("Awaiting for a clean slate");
-    app.identity_processor.await_clean_slate().await?;
-
-    tracing::info!("Awaiting for initialized tree");
-    app.tree_state()?;
-
     tracing::info!("Starting batch creator.");
     ensure_batch_chain_initialized(&app).await?;
 

--- a/src/task_monitor/tasks/finalize_identities.rs
+++ b/src/task_monitor/tasks/finalize_identities.rs
@@ -1,15 +1,23 @@
 use std::sync::Arc;
 
-use tokio::sync::Notify;
-
 use crate::app::App;
+use tokio::sync::Notify;
+use tokio::time;
+use tokio::time::MissedTickBehavior;
+use tracing::info;
 
 pub async fn finalize_roots(app: Arc<App>, sync_tree_notify: Arc<Notify>) -> anyhow::Result<()> {
+    info!("Starting finalize roots task.");
+
+    let mut timer = time::interval(app.config.app.time_between_scans);
+    timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
     loop {
+        timer.tick().await;
+        info!("Finalize roots woken due to timeout.");
+
         app.identity_processor
             .finalize_identities(&sync_tree_notify)
             .await?;
-
-        tokio::time::sleep(app.config.app.time_between_scans).await;
     }
 }

--- a/src/task_monitor/tasks/modify_tree.rs
+++ b/src/task_monitor/tasks/modify_tree.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 use sqlx::{Postgres, Transaction};
 use tokio::sync::watch::Receiver;
 use tokio::sync::Notify;
+use tokio::time::MissedTickBehavior;
 use tokio::{select, time};
 use tracing::{info, warn};
 
@@ -32,6 +33,7 @@ pub async fn modify_tree(
     let min_batch_deletion_size = app.config.app.min_batch_deletion_size;
 
     let mut timer = time::interval(Duration::from_secs(5));
+    timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
         // We wait either for a timer tick or a event that tree was synchronized

--- a/src/task_monitor/tasks/monitor_txs.rs
+++ b/src/task_monitor/tasks/monitor_txs.rs
@@ -13,7 +13,7 @@ pub async fn monitor_txs(
 
     while let Some(tx) = monitored_txs_receiver.recv().await {
         assert!(
-            (app.identity_processor.mine_transaction(tx.clone()).await?),
+            app.identity_processor.mine_transaction(tx.clone()).await?,
             "Failed to mine transaction: {}",
             tx
         );

--- a/tests/tree_restore_with_root_back_to_init.rs
+++ b/tests/tree_restore_with_root_back_to_init.rs
@@ -147,12 +147,10 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
 
     info!("Starting the app again for testing purposes");
 
-    let (_, app_handle, local_addr, shutdown, initialized_tree_state) =
+    let (_, app_handle, _, shutdown, initialized_tree_state) =
         spawn_app_returning_initialized_tree(config.clone())
             .await
             .expect("Failed to spawn app.");
-
-    let uri = "http://".to_owned() + &local_addr.to_string();
 
     let restored_tree_state = initialized_tree_state;
 
@@ -162,56 +160,12 @@ async fn tree_restore_with_root_back_to_init(offchain_mode_enabled: bool) -> any
     );
     assert_eq!(
         restored_tree_state.batching_tree().get_root(),
-        initial_root.into()
+        tree_state.batching_tree().get_root()
     );
     assert_eq!(
         restored_tree_state.processed_tree().get_root(),
         initial_root.into()
     );
-
-    tokio::time::sleep(Duration::from_secs(IDLE_TIME)).await;
-
-    // Check that we can also get these inclusion proofs back.
-    test_inclusion_proof(
-        &mock_chain,
-        &uri,
-        &client,
-        0,
-        &ref_tree,
-        &Hash::from_str_radix(&test_identities[0], 16)
-            .expect("Failed to parse Hash from test leaf 0"),
-        false,
-        offchain_mode_enabled,
-    )
-    .await;
-    test_inclusion_proof(
-        &mock_chain,
-        &uri,
-        &client,
-        1,
-        &ref_tree,
-        &Hash::from_str_radix(&test_identities[1], 16)
-            .expect("Failed to parse Hash from test leaf 1"),
-        false,
-        offchain_mode_enabled,
-    )
-    .await;
-    test_inclusion_proof(
-        &mock_chain,
-        &uri,
-        &client,
-        2,
-        &ref_tree,
-        &Hash::from_str_radix(&test_identities[2], 16)
-            .expect("Failed to parse Hash from test leaf 2"),
-        false,
-        offchain_mode_enabled,
-    )
-    .await;
-
-    tokio::time::sleep(Duration::from_secs(2)).await;
-
-    test_same_tree_states(tree_state, &restored_tree_state).await?;
 
     // Shutdown the app properly for the final time
     shutdown.shutdown();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

With multiple instances running same time it is possible that batches will be removed when they shouldn't (transaction not yet mined but scheduled and during that time instance starts).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

We should not remove batches from database at all. Relayer should handle network reorgs by retrying already send transactions that were reverted.
Added small refactor with names for tasks to simplify debugging.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
