### PR TITLE
feat: upgrade authorized_keys to support multiple PEM entries with optional expiry.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -43,8 +43,7 @@ mod authorized_keys_serde {
             }
 
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
-                serde_json::from_str::<HashMap<String, Vec<AuthorizedKey>>>(v)
-                    .map_err(E::custom)
+                serde_json::from_str::<HashMap<String, Vec<AuthorizedKey>>>(v).map_err(E::custom)
             }
         }
 
@@ -61,13 +60,13 @@ mod authorized_keys_serde {
                 type Value = KeyList;
 
                 fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                    write!(f, "a sequence of authorized keys or a JSON-encoded sequence")
+                    write!(
+                        f,
+                        "a sequence of authorized keys or a JSON-encoded sequence"
+                    )
                 }
 
-                fn visit_seq<A: SeqAccess<'de>>(
-                    self,
-                    mut seq: A,
-                ) -> Result<Self::Value, A::Error> {
+                fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
                     let mut keys = Vec::new();
                     while let Some(key) = seq.next_element::<AuthorizedKey>()? {
                         keys.push(key);
@@ -336,7 +335,12 @@ pub struct ServerConfig {
     pub basic_auth_credentials: HashMap<String, String>,
 
     /// Named authorized keys for JWT authentication: key_name -> list of authorized keys
-    #[serde(rename = "authorized_keys_json", alias = "authorized_keys", default, deserialize_with = "authorized_keys_serde::deserialize")]
+    #[serde(
+        rename = "authorized_keys_json",
+        alias = "authorized_keys",
+        default,
+        deserialize_with = "authorized_keys_serde::deserialize"
+    )]
     pub authorized_keys: HashMap<String, Vec<AuthorizedKey>>,
 }
 
@@ -870,7 +874,8 @@ mod tests {
         let keys: HashMap<String, Vec<AuthorizedKey>> = toml::from_str(indoc::indoc! {r#"
             key1 = [{ pem = "pem_content_1" }]
             key2 = [{ pem = "pem_content_2" }]
-        "#}).unwrap();
+        "#})
+        .unwrap();
 
         assert_eq!(keys.len(), 2);
         assert_eq!(keys["key1"][0].pem, "pem_content_1");
@@ -884,7 +889,8 @@ mod tests {
                 { pem = "old_pem_content" },
                 { pem = "new_pem_content" },
             ]
-        "#}).unwrap();
+        "#})
+        .unwrap();
 
         assert_eq!(keys["app_backend"].len(), 2);
         assert_eq!(keys["app_backend"][0].pem, "old_pem_content");
@@ -900,7 +906,8 @@ mod tests {
                 { pem = "old_pem_content", expires_at = "2025-01-01T00:00:00Z" },
                 { pem = "new_pem_content" },
             ]
-        "#}).unwrap();
+        "#})
+        .unwrap();
 
         assert_eq!(keys["app_backend"].len(), 2);
         assert!(keys["app_backend"][0].expires_at.is_some());
@@ -920,8 +927,14 @@ mod tests {
         let config: Config = load_config(None).unwrap();
 
         assert_eq!(config.server.authorized_keys.len(), 2);
-        assert_eq!(config.server.authorized_keys["key1"][0].pem, "pem_content_1");
-        assert_eq!(config.server.authorized_keys["key2"][0].pem, "pem_content_2");
+        assert_eq!(
+            config.server.authorized_keys["key1"][0].pem,
+            "pem_content_1"
+        );
+        assert_eq!(
+            config.server.authorized_keys["key2"][0].pem,
+            "pem_content_2"
+        );
 
         purge_env(OFFCHAIN_ENV);
         std::env::remove_var("SEQ__SERVER__AUTHORIZED_KEYS_JSON");
@@ -940,8 +953,14 @@ mod tests {
         let config: Config = load_config(None).unwrap();
 
         assert_eq!(config.server.authorized_keys["app_backend"].len(), 2);
-        assert_eq!(config.server.authorized_keys["app_backend"][0].pem, "old_pem_content");
-        assert_eq!(config.server.authorized_keys["app_backend"][1].pem, "new_pem_content");
+        assert_eq!(
+            config.server.authorized_keys["app_backend"][0].pem,
+            "old_pem_content"
+        );
+        assert_eq!(
+            config.server.authorized_keys["app_backend"][1].pem,
+            "new_pem_content"
+        );
 
         purge_env(OFFCHAIN_ENV);
         std::env::remove_var("SEQ__SERVER__AUTHORIZED_KEYS_JSON");

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use ethers::types::{Address, H160};
 use semaphore_rs::Field;
 use serde::{Deserialize, Serialize};
@@ -10,6 +11,81 @@ use serde::{Deserialize, Serialize};
 use crate::prover::ProverConfig;
 use crate::utils::secret::SecretUrl;
 use crate::utils::serde_utils::JsonStrWrapper;
+
+/// The `config` crate (0.13) stores env var values as raw strings even with `try_parsing(true)`.
+/// This module provides a custom deserializer for `HashMap<String, Vec<AuthorizedKey>>` that
+/// accepts both sequences (TOML) and JSON-encoded strings (env vars).
+mod authorized_keys_serde {
+    use super::AuthorizedKey;
+    use serde::de::{MapAccess, SeqAccess, Visitor};
+    use serde::{Deserialize, Deserializer};
+    use std::collections::HashMap;
+
+    pub fn deserialize<'de, D>(d: D) -> Result<HashMap<String, Vec<AuthorizedKey>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct MapVisitor;
+
+        impl<'de> Visitor<'de> for MapVisitor {
+            type Value = HashMap<String, Vec<AuthorizedKey>>;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "a map of key names to authorized key lists")
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                let mut result = HashMap::new();
+                while let Some((name, keys)) = map.next_entry::<String, KeyList>()? {
+                    result.insert(name, keys.0);
+                }
+                Ok(result)
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                serde_json::from_str::<HashMap<String, Vec<AuthorizedKey>>>(v)
+                    .map_err(E::custom)
+            }
+        }
+
+        d.deserialize_any(MapVisitor)
+    }
+
+    struct KeyList(Vec<AuthorizedKey>);
+
+    impl<'de> Deserialize<'de> for KeyList {
+        fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+            struct KeyListVisitor;
+
+            impl<'de> Visitor<'de> for KeyListVisitor {
+                type Value = KeyList;
+
+                fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    write!(f, "a sequence of authorized keys or a JSON-encoded sequence")
+                }
+
+                fn visit_seq<A: SeqAccess<'de>>(
+                    self,
+                    mut seq: A,
+                ) -> Result<Self::Value, A::Error> {
+                    let mut keys = Vec::new();
+                    while let Some(key) = seq.next_element::<AuthorizedKey>()? {
+                        keys.push(key);
+                    }
+                    Ok(KeyList(keys))
+                }
+
+                fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                    serde_json::from_str::<Vec<AuthorizedKey>>(v)
+                        .map(KeyList)
+                        .map_err(E::custom)
+                }
+            }
+
+            d.deserialize_any(KeyListVisitor)
+        }
+    }
+}
 
 /// Authentication mode for the server API endpoints.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -238,6 +314,12 @@ pub struct DatabaseConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorizedKey {
+    pub pem: String,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServerConfig {
     pub address: SocketAddr,
 
@@ -253,9 +335,9 @@ pub struct ServerConfig {
     #[serde(default)]
     pub basic_auth_credentials: HashMap<String, String>,
 
-    /// Named authorized keys for JWT authentication: key_name -> PEM public key
-    #[serde(default)]
-    pub authorized_keys: HashMap<String, String>,
+    /// Named authorized keys for JWT authentication: key_name -> list of authorized keys
+    #[serde(rename = "authorized_keys_json", alias = "authorized_keys", default, deserialize_with = "authorized_keys_serde::deserialize")]
+    pub authorized_keys: HashMap<String, Vec<AuthorizedKey>>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -448,7 +530,7 @@ mod tests {
 
         [server.basic_auth_credentials]
 
-        [server.authorized_keys]
+        [server.authorized_keys_json]
 
         [service]
         service_name = "signup-sequencer"
@@ -493,7 +575,7 @@ mod tests {
 
         [server.basic_auth_credentials]
 
-        [server.authorized_keys]
+        [server.authorized_keys_json]
 
         [service]
         service_name = "signup-sequencer"
@@ -694,8 +776,8 @@ mod tests {
         app_backend = "secretpass123"
         other_service = "otherpass456"
 
-        [server.authorized_keys]
-        app_backend = "test_public_key_pem_content"
+        [server.authorized_keys_json]
+        app_backend = [{ pem = "test_public_key_pem_content" }]
 
         [service]
         service_name = "signup-sequencer"
@@ -735,7 +817,7 @@ mod tests {
         SEQ__SERVER__AUTH_MODE=basic_or_jwt
         SEQ__SERVER__BASIC_AUTH_CREDENTIALS__APP_BACKEND=secretpass123
         SEQ__SERVER__BASIC_AUTH_CREDENTIALS__OTHER_SERVICE=otherpass456
-        SEQ__SERVER__AUTHORIZED_KEYS__APP_BACKEND=test_public_key_pem_content
+        SEQ__SERVER__AUTHORIZED_KEYS_JSON={"app_backend":[{"pem":"test_public_key_pem_content"}]}
 
         SEQ__SERVICE__SERVICE_NAME=signup-sequencer
 
@@ -781,6 +863,88 @@ mod tests {
         assert_eq!(parsed_config, env_config);
 
         purge_env(AUTH_ENV);
+    }
+
+    #[test]
+    fn authorized_keys_multiple_names_from_toml() {
+        let keys: HashMap<String, Vec<AuthorizedKey>> = toml::from_str(indoc::indoc! {r#"
+            key1 = [{ pem = "pem_content_1" }]
+            key2 = [{ pem = "pem_content_2" }]
+        "#}).unwrap();
+
+        assert_eq!(keys.len(), 2);
+        assert_eq!(keys["key1"][0].pem, "pem_content_1");
+        assert_eq!(keys["key2"][0].pem, "pem_content_2");
+    }
+
+    #[test]
+    fn authorized_keys_multiple_pems_per_name_from_toml() {
+        let keys: HashMap<String, Vec<AuthorizedKey>> = toml::from_str(indoc::indoc! {r#"
+            app_backend = [
+                { pem = "old_pem_content" },
+                { pem = "new_pem_content" },
+            ]
+        "#}).unwrap();
+
+        assert_eq!(keys["app_backend"].len(), 2);
+        assert_eq!(keys["app_backend"][0].pem, "old_pem_content");
+        assert_eq!(keys["app_backend"][1].pem, "new_pem_content");
+        assert!(keys["app_backend"][0].expires_at.is_none());
+        assert!(keys["app_backend"][1].expires_at.is_none());
+    }
+
+    #[test]
+    fn authorized_keys_multiple_pems_per_name_with_expiry_from_toml() {
+        let keys: HashMap<String, Vec<AuthorizedKey>> = toml::from_str(indoc::indoc! {r#"
+            app_backend = [
+                { pem = "old_pem_content", expires_at = "2025-01-01T00:00:00Z" },
+                { pem = "new_pem_content" },
+            ]
+        "#}).unwrap();
+
+        assert_eq!(keys["app_backend"].len(), 2);
+        assert!(keys["app_backend"][0].expires_at.is_some());
+        assert!(keys["app_backend"][1].expires_at.is_none());
+    }
+
+    #[test]
+    fn authorized_keys_multiple_names_from_env() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+
+        load_env(OFFCHAIN_ENV);
+        std::env::set_var(
+            "SEQ__SERVER__AUTHORIZED_KEYS_JSON",
+            r#"{"key1":[{"pem":"pem_content_1"}],"key2":[{"pem":"pem_content_2"}]}"#,
+        );
+
+        let config: Config = load_config(None).unwrap();
+
+        assert_eq!(config.server.authorized_keys.len(), 2);
+        assert_eq!(config.server.authorized_keys["key1"][0].pem, "pem_content_1");
+        assert_eq!(config.server.authorized_keys["key2"][0].pem, "pem_content_2");
+
+        purge_env(OFFCHAIN_ENV);
+        std::env::remove_var("SEQ__SERVER__AUTHORIZED_KEYS_JSON");
+    }
+
+    #[test]
+    fn authorized_keys_multiple_pems_per_name_from_env() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+
+        load_env(OFFCHAIN_ENV);
+        std::env::set_var(
+            "SEQ__SERVER__AUTHORIZED_KEYS_JSON",
+            r#"{"app_backend":[{"pem":"old_pem_content"},{"pem":"new_pem_content"}]}"#,
+        );
+
+        let config: Config = load_config(None).unwrap();
+
+        assert_eq!(config.server.authorized_keys["app_backend"].len(), 2);
+        assert_eq!(config.server.authorized_keys["app_backend"][0].pem, "old_pem_content");
+        assert_eq!(config.server.authorized_keys["app_backend"][1].pem, "new_pem_content");
+
+        purge_env(OFFCHAIN_ENV);
+        std::env::remove_var("SEQ__SERVER__AUTHORIZED_KEYS_JSON");
     }
 
     #[test]

--- a/src/utils/auth.rs
+++ b/src/utils/auth.rs
@@ -6,7 +6,7 @@ use axum::extract::Request;
 use axum::response::Response;
 use base64::prelude::*;
 
-use crate::config::AuthMode;
+use crate::config::{AuthMode, AuthorizedKey};
 use crate::utils::jwt::JwtValidator;
 
 use super::jwt::JwtError;
@@ -40,7 +40,7 @@ impl AuthValidator {
     pub fn new(
         mode: AuthMode,
         basic_credentials: HashMap<String, String>,
-        jwt_keys: &HashMap<String, String>,
+        jwt_keys: &HashMap<String, Vec<AuthorizedKey>>,
     ) -> Result<Self, JwtError> {
         // Build JWT validator if mode requires it
         let jwt_validator = JwtValidator::new(jwt_keys)?;

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -1,7 +1,16 @@
+use chrono::{DateTime, Utc};
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use thiserror::Error;
+
+use crate::config::AuthorizedKey;
+
+#[derive(Clone)]
+struct LoadedKey {
+    key: DecodingKey,
+    expires_at: Option<DateTime<Utc>>,
+}
 
 /// JWT claims structure.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,19 +40,25 @@ pub enum JwtError {
 
 #[derive(Clone)]
 pub struct JwtValidator {
-    keys: HashMap<String, DecodingKey>,
+    keys: HashMap<String, Vec<LoadedKey>>,
 }
 
 impl JwtValidator {
-    /// Creates a new JWT validator from a map of named PEM public keys.
+    /// Creates a new JWT validator from a map of named authorized keys.
     ///
     /// # Errors
     /// Returns an error if any of the provided PEM keys are invalid.
-    pub fn new(pem_keys: &HashMap<String, String>) -> Result<Self, JwtError> {
+    pub fn new(authorized_keys: &HashMap<String, Vec<AuthorizedKey>>) -> Result<Self, JwtError> {
         let mut keys = HashMap::new();
-        for (name, pem) in pem_keys {
-            let key = DecodingKey::from_ec_pem(pem.as_bytes())?;
-            keys.insert(name.clone(), key);
+        for (name, entries) in authorized_keys {
+            let mut loaded = Vec::new();
+            for entry in entries {
+                loaded.push(LoadedKey {
+                    key: DecodingKey::from_ec_pem(entry.pem.as_bytes())?,
+                    expires_at: entry.expires_at,
+                });
+            }
+            keys.insert(name.clone(), loaded);
         }
         Ok(Self { keys })
     }
@@ -65,11 +80,17 @@ impl JwtValidator {
     pub fn validate(&self, token: &str) -> Result<Claims, JwtError> {
         let validation = Validation::new(Algorithm::ES256);
 
-        for (name, key) in &self.keys {
-            if let Ok(token_data) = decode::<Claims>(token, key, &validation) {
-                // Signature valid - now check sub matches key name
-                if token_data.claims.sub == *name {
-                    return Ok(token_data.claims);
+        let now = Utc::now();
+        for (name, keys) in &self.keys {
+            for loaded in keys {
+                if loaded.expires_at.is_some_and(|exp| exp <= now) {
+                    continue;
+                }
+                if let Ok(token_data) = decode::<Claims>(token, &loaded.key, &validation) {
+                    // Signature valid - now check sub matches key name
+                    if token_data.claims.sub == *name {
+                        return Ok(token_data.claims);
+                    }
                 }
             }
         }
@@ -105,7 +126,7 @@ mod tests {
         let (private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), public_pem);
+        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -122,7 +143,7 @@ mod tests {
         let (private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), public_pem);
+        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -138,7 +159,7 @@ mod tests {
         let (private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), public_pem);
+        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -155,7 +176,7 @@ mod tests {
         let (private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), public_pem);
+        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -173,7 +194,7 @@ mod tests {
         let (_private_pem2, public_pem2) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), public_pem2);
+        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem2, expires_at: None }]);
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -190,7 +211,7 @@ mod tests {
         let (_private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), public_pem);
+        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -204,8 +225,8 @@ mod tests {
         let (private_pem2, public_pem2) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("key1".to_string(), public_pem1);
-        keys.insert("key2".to_string(), public_pem2);
+        keys.insert("key1".to_string(), vec![AuthorizedKey { pem: public_pem1, expires_at: None }]);
+        keys.insert("key2".to_string(), vec![AuthorizedKey { pem: public_pem2, expires_at: None }]);
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -238,6 +259,107 @@ mod tests {
     }
 
     #[test]
+    fn multiple_pems_per_key_both_validate() {
+        let (private_pem1, public_pem1) = generate_es256_keypair();
+        let (private_pem2, public_pem2) = generate_es256_keypair();
+
+        let mut keys = HashMap::new();
+        keys.insert("test_key".to_string(), vec![
+            AuthorizedKey { pem: public_pem1, expires_at: None },
+            AuthorizedKey { pem: public_pem2, expires_at: None },
+        ]);
+
+        let validator = JwtValidator::new(&keys).expect("Failed to create validator");
+
+        for private_pem in [&private_pem1, &private_pem2] {
+            let claims = Claims::new("test_key", future_exp());
+            let token = sign_jwt(private_pem, &claims);
+            let result = validator.validate(&token);
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap().sub, "test_key");
+        }
+    }
+
+    #[test]
+    fn multiple_pems_per_key_wrong_sub_still_rejected() {
+        let (private_pem1, public_pem1) = generate_es256_keypair();
+        let (_private_pem2, public_pem2) = generate_es256_keypair();
+
+        let mut keys = HashMap::new();
+        keys.insert("key1".to_string(), vec![
+            AuthorizedKey { pem: public_pem1, expires_at: None },
+            AuthorizedKey { pem: public_pem2, expires_at: None },
+        ]);
+
+        let validator = JwtValidator::new(&keys).expect("Failed to create validator");
+
+        // Token signed with key1's private key but claiming sub=key2 — must be rejected
+        let claims = Claims::new("key2", future_exp());
+        let token = sign_jwt(&private_pem1, &claims);
+        assert!(matches!(validator.validate(&token), Err(JwtError::InvalidToken)));
+    }
+
+    #[test]
+    fn key_with_future_expiry_accepts_valid_token() {
+        let (private_pem, public_pem) = generate_es256_keypair();
+
+        let mut keys = HashMap::new();
+        keys.insert("test_key".to_string(), vec![AuthorizedKey {
+            pem: public_pem,
+            expires_at: Some(Utc::now() + chrono::Duration::hours(1)),
+        }]);
+
+        let validator = JwtValidator::new(&keys).expect("Failed to create validator");
+
+        let claims = Claims::new("test_key", future_exp());
+        let token = sign_jwt(&private_pem, &claims);
+
+        assert!(validator.validate(&token).is_ok());
+    }
+
+    #[test]
+    fn key_with_past_expiry_rejects_valid_token() {
+        let (private_pem, public_pem) = generate_es256_keypair();
+
+        let mut keys = HashMap::new();
+        keys.insert("test_key".to_string(), vec![AuthorizedKey {
+            pem: public_pem,
+            expires_at: Some(Utc::now() - chrono::Duration::hours(1)),
+        }]);
+
+        let validator = JwtValidator::new(&keys).expect("Failed to create validator");
+
+        let claims = Claims::new("test_key", future_exp());
+        let token = sign_jwt(&private_pem, &claims);
+
+        assert!(matches!(validator.validate(&token), Err(JwtError::InvalidToken)));
+    }
+
+    #[test]
+    fn expired_key_superseded_by_valid_key_with_same_name() {
+        let (private_pem, public_pem) = generate_es256_keypair();
+
+        let mut keys = HashMap::new();
+        keys.insert("test_key".to_string(), vec![
+            AuthorizedKey {
+                pem: public_pem.clone(),
+                expires_at: Some(Utc::now() - chrono::Duration::hours(1)),
+            },
+            AuthorizedKey {
+                pem: public_pem,
+                expires_at: None,
+            },
+        ]);
+
+        let validator = JwtValidator::new(&keys).expect("Failed to create validator");
+
+        let claims = Claims::new("test_key", future_exp());
+        let token = sign_jwt(&private_pem, &claims);
+
+        assert!(validator.validate(&token).is_ok());
+    }
+
+    #[test]
     fn has_keys_returns_correct_value() {
         let empty_keys = HashMap::new();
         let validator_empty = JwtValidator::new(&empty_keys).expect("Failed to create validator");
@@ -245,7 +367,7 @@ mod tests {
 
         let (_, public_pem) = generate_es256_keypair();
         let mut keys = HashMap::new();
-        keys.insert("test".to_string(), public_pem);
+        keys.insert("test".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
         let validator_with_keys = JwtValidator::new(&keys).expect("Failed to create validator");
         assert!(validator_with_keys.has_keys());
     }

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -126,7 +126,13 @@ mod tests {
         let (private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
+        keys.insert(
+            "test_key".to_string(),
+            vec![AuthorizedKey {
+                pem: public_pem,
+                expires_at: None,
+            }],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -143,7 +149,13 @@ mod tests {
         let (private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
+        keys.insert(
+            "test_key".to_string(),
+            vec![AuthorizedKey {
+                pem: public_pem,
+                expires_at: None,
+            }],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -159,7 +171,13 @@ mod tests {
         let (private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
+        keys.insert(
+            "test_key".to_string(),
+            vec![AuthorizedKey {
+                pem: public_pem,
+                expires_at: None,
+            }],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -176,7 +194,13 @@ mod tests {
         let (private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
+        keys.insert(
+            "test_key".to_string(),
+            vec![AuthorizedKey {
+                pem: public_pem,
+                expires_at: None,
+            }],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -194,7 +218,13 @@ mod tests {
         let (_private_pem2, public_pem2) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem2, expires_at: None }]);
+        keys.insert(
+            "test_key".to_string(),
+            vec![AuthorizedKey {
+                pem: public_pem2,
+                expires_at: None,
+            }],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -211,7 +241,13 @@ mod tests {
         let (_private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
+        keys.insert(
+            "test_key".to_string(),
+            vec![AuthorizedKey {
+                pem: public_pem,
+                expires_at: None,
+            }],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -225,8 +261,20 @@ mod tests {
         let (private_pem2, public_pem2) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("key1".to_string(), vec![AuthorizedKey { pem: public_pem1, expires_at: None }]);
-        keys.insert("key2".to_string(), vec![AuthorizedKey { pem: public_pem2, expires_at: None }]);
+        keys.insert(
+            "key1".to_string(),
+            vec![AuthorizedKey {
+                pem: public_pem1,
+                expires_at: None,
+            }],
+        );
+        keys.insert(
+            "key2".to_string(),
+            vec![AuthorizedKey {
+                pem: public_pem2,
+                expires_at: None,
+            }],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -264,10 +312,19 @@ mod tests {
         let (private_pem2, public_pem2) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), vec![
-            AuthorizedKey { pem: public_pem1, expires_at: None },
-            AuthorizedKey { pem: public_pem2, expires_at: None },
-        ]);
+        keys.insert(
+            "test_key".to_string(),
+            vec![
+                AuthorizedKey {
+                    pem: public_pem1,
+                    expires_at: None,
+                },
+                AuthorizedKey {
+                    pem: public_pem2,
+                    expires_at: None,
+                },
+            ],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -286,17 +343,29 @@ mod tests {
         let (_private_pem2, public_pem2) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("key1".to_string(), vec![
-            AuthorizedKey { pem: public_pem1, expires_at: None },
-            AuthorizedKey { pem: public_pem2, expires_at: None },
-        ]);
+        keys.insert(
+            "key1".to_string(),
+            vec![
+                AuthorizedKey {
+                    pem: public_pem1,
+                    expires_at: None,
+                },
+                AuthorizedKey {
+                    pem: public_pem2,
+                    expires_at: None,
+                },
+            ],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
         // Token signed with key1's private key but claiming sub=key2 — must be rejected
         let claims = Claims::new("key2", future_exp());
         let token = sign_jwt(&private_pem1, &claims);
-        assert!(matches!(validator.validate(&token), Err(JwtError::InvalidToken)));
+        assert!(matches!(
+            validator.validate(&token),
+            Err(JwtError::InvalidToken)
+        ));
     }
 
     #[test]
@@ -304,10 +373,13 @@ mod tests {
         let (private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), vec![AuthorizedKey {
-            pem: public_pem,
-            expires_at: Some(Utc::now() + chrono::Duration::hours(1)),
-        }]);
+        keys.insert(
+            "test_key".to_string(),
+            vec![AuthorizedKey {
+                pem: public_pem,
+                expires_at: Some(Utc::now() + chrono::Duration::hours(1)),
+            }],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -322,17 +394,23 @@ mod tests {
         let (private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), vec![AuthorizedKey {
-            pem: public_pem,
-            expires_at: Some(Utc::now() - chrono::Duration::hours(1)),
-        }]);
+        keys.insert(
+            "test_key".to_string(),
+            vec![AuthorizedKey {
+                pem: public_pem,
+                expires_at: Some(Utc::now() - chrono::Duration::hours(1)),
+            }],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
         let claims = Claims::new("test_key", future_exp());
         let token = sign_jwt(&private_pem, &claims);
 
-        assert!(matches!(validator.validate(&token), Err(JwtError::InvalidToken)));
+        assert!(matches!(
+            validator.validate(&token),
+            Err(JwtError::InvalidToken)
+        ));
     }
 
     #[test]
@@ -340,16 +418,19 @@ mod tests {
         let (private_pem, public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
-        keys.insert("test_key".to_string(), vec![
-            AuthorizedKey {
-                pem: public_pem.clone(),
-                expires_at: Some(Utc::now() - chrono::Duration::hours(1)),
-            },
-            AuthorizedKey {
-                pem: public_pem,
-                expires_at: None,
-            },
-        ]);
+        keys.insert(
+            "test_key".to_string(),
+            vec![
+                AuthorizedKey {
+                    pem: public_pem.clone(),
+                    expires_at: Some(Utc::now() - chrono::Duration::hours(1)),
+                },
+                AuthorizedKey {
+                    pem: public_pem,
+                    expires_at: None,
+                },
+            ],
+        );
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
@@ -367,7 +448,13 @@ mod tests {
 
         let (_, public_pem) = generate_es256_keypair();
         let mut keys = HashMap::new();
-        keys.insert("test".to_string(), vec![AuthorizedKey { pem: public_pem, expires_at: None }]);
+        keys.insert(
+            "test".to_string(),
+            vec![AuthorizedKey {
+                pem: public_pem,
+                expires_at: None,
+            }],
+        );
         let validator_with_keys = JwtValidator::new(&keys).expect("Failed to create validator");
         assert!(validator_with_keys.has_keys());
     }

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -83,14 +83,16 @@ impl JwtValidator {
         let now = Utc::now();
         for (name, keys) in &self.keys {
             for loaded in keys {
-                if loaded.expires_at.is_some_and(|exp| exp <= now) {
-                    continue;
-                }
                 if let Ok(token_data) = decode::<Claims>(token, &loaded.key, &validation) {
                     // Signature valid - now check sub matches key name
-                    if token_data.claims.sub == *name {
-                        return Ok(token_data.claims);
+                    if token_data.claims.sub != *name {
+                        continue;
                     }
+                    if loaded.expires_at.is_some_and(|exp| exp <= now) {
+                        tracing::warn!(key = %name, "JWT validated against an expired authorized key");
+                        return Err(JwtError::InvalidToken);
+                    }
+                    return Ok(token_data.claims);
                 }
             }
         }
@@ -414,19 +416,20 @@ mod tests {
     }
 
     #[test]
-    fn expired_key_superseded_by_valid_key_with_same_name() {
-        let (private_pem, public_pem) = generate_es256_keypair();
+    fn new_key_accepted_when_old_key_expired() {
+        let (old_private_pem, old_public_pem) = generate_es256_keypair();
+        let (new_private_pem, new_public_pem) = generate_es256_keypair();
 
         let mut keys = HashMap::new();
         keys.insert(
             "test_key".to_string(),
             vec![
                 AuthorizedKey {
-                    pem: public_pem.clone(),
+                    pem: old_public_pem,
                     expires_at: Some(Utc::now() - chrono::Duration::hours(1)),
                 },
                 AuthorizedKey {
-                    pem: public_pem,
+                    pem: new_public_pem,
                     expires_at: None,
                 },
             ],
@@ -434,10 +437,17 @@ mod tests {
 
         let validator = JwtValidator::new(&keys).expect("Failed to create validator");
 
+        // Token signed with new key — accepted
         let claims = Claims::new("test_key", future_exp());
-        let token = sign_jwt(&private_pem, &claims);
-
+        let token = sign_jwt(&new_private_pem, &claims);
         assert!(validator.validate(&token).is_ok());
+
+        // Token signed with old (expired) key — rejected with warning
+        let old_token = sign_jwt(&old_private_pem, &claims);
+        assert!(matches!(
+            validator.validate(&old_token),
+            Err(JwtError::InvalidToken)
+        ));
     }
 
     #[test]

--- a/tests/jwt_auth.rs
+++ b/tests/jwt_auth.rs
@@ -9,7 +9,7 @@ use common::prelude::*;
 use common::{generate_es256_keypair, sign_jwt};
 use maplit::hashmap;
 use reqwest::header::AUTHORIZATION;
-use signup_sequencer::config::AuthMode;
+use signup_sequencer::config::{AuthMode, AuthorizedKey};
 use signup_sequencer::utils::jwt::Claims;
 
 fn future_exp() -> u64 {
@@ -22,7 +22,7 @@ fn future_exp() -> u64 {
 
 async fn setup_test_app_with_auth(
     auth_mode: AuthMode,
-    authorized_keys: HashMap<String, String>,
+    authorized_keys: HashMap<String, Vec<AuthorizedKey>>,
     basic_auth_credentials: HashMap<String, String>,
 ) -> anyhow::Result<(
     std::sync::Arc<signup_sequencer::app::App>,
@@ -77,7 +77,7 @@ async fn health_no_auth_required() -> anyhow::Result<()> {
     init_tracing_subscriber();
 
     let (_, public_pem) = generate_es256_keypair();
-    let keys = hashmap! { "test_key".to_string() => public_pem };
+    let keys = hashmap! { "test_key".to_string() => vec![AuthorizedKey { pem: public_pem, expires_at: None }] };
 
     let (_app, app_handle, local_addr, shutdown, _db, _temp) =
         setup_test_app_with_auth(AuthMode::JwtOnly, keys, hashmap! {}).await?;
@@ -101,7 +101,7 @@ async fn metrics_no_auth_required() -> anyhow::Result<()> {
     init_tracing_subscriber();
 
     let (_, public_pem) = generate_es256_keypair();
-    let keys = hashmap! { "test_key".to_string() => public_pem };
+    let keys = hashmap! { "test_key".to_string() => vec![AuthorizedKey { pem: public_pem, expires_at: None }] };
 
     let (_app, app_handle, local_addr, shutdown, _db, _temp) =
         setup_test_app_with_auth(AuthMode::JwtOnly, keys, hashmap! {}).await?;
@@ -125,7 +125,7 @@ async fn insert_identity_requires_auth_when_enforced() -> anyhow::Result<()> {
     init_tracing_subscriber();
 
     let (_, public_pem) = generate_es256_keypair();
-    let keys = hashmap! { "test_key".to_string() => public_pem };
+    let keys = hashmap! { "test_key".to_string() => vec![AuthorizedKey { pem: public_pem, expires_at: None }] };
 
     let (_app, app_handle, local_addr, shutdown, _db, _temp) =
         setup_test_app_with_auth(AuthMode::JwtOnly, keys, hashmap! {}).await?;
@@ -153,7 +153,7 @@ async fn insert_identity_succeeds_with_valid_token() -> anyhow::Result<()> {
     init_tracing_subscriber();
 
     let (private_pem, public_pem) = generate_es256_keypair();
-    let keys = hashmap! { "test_key".to_string() => public_pem };
+    let keys = hashmap! { "test_key".to_string() => vec![AuthorizedKey { pem: public_pem, expires_at: None }] };
 
     let (_app, app_handle, local_addr, shutdown, _db, _temp) =
         setup_test_app_with_auth(AuthMode::JwtOnly, keys, hashmap! {}).await?;
@@ -186,7 +186,7 @@ async fn auth_disabled_bypasses_all_checks() -> anyhow::Result<()> {
     init_tracing_subscriber();
 
     let (_, public_pem) = generate_es256_keypair();
-    let keys = hashmap! { "test_key".to_string() => public_pem };
+    let keys = hashmap! { "test_key".to_string() => vec![AuthorizedKey { pem: public_pem, expires_at: None }] };
 
     // Auth is disabled entirely
     let (_app, app_handle, local_addr, shutdown, _db, _temp) =
@@ -216,7 +216,7 @@ async fn basic_or_jwt_allows_with_basic_auth() -> anyhow::Result<()> {
     init_tracing_subscriber();
 
     let (_, public_pem) = generate_es256_keypair();
-    let keys = hashmap! { "test_key".to_string() => public_pem };
+    let keys = hashmap! { "test_key".to_string() => vec![AuthorizedKey { pem: public_pem, expires_at: None }] };
 
     let basic_creds = hashmap! { "testuser".to_string() => "testpass".to_string() };
 
@@ -249,7 +249,7 @@ async fn basic_or_jwt_allows_with_jwt_only() -> anyhow::Result<()> {
     init_tracing_subscriber();
 
     let (private_pem, public_pem) = generate_es256_keypair();
-    let keys = hashmap! { "test_key".to_string() => public_pem };
+    let keys = hashmap! { "test_key".to_string() => vec![AuthorizedKey { pem: public_pem, expires_at: None }] };
 
     let basic_creds = hashmap! { "testuser".to_string() => "testpass".to_string() };
 
@@ -285,7 +285,7 @@ async fn v2_insert_identity_requires_auth_when_enforced() -> anyhow::Result<()> 
     init_tracing_subscriber();
 
     let (_, public_pem) = generate_es256_keypair();
-    let keys = hashmap! { "test_key".to_string() => public_pem };
+    let keys = hashmap! { "test_key".to_string() => vec![AuthorizedKey { pem: public_pem, expires_at: None }] };
 
     let (_app, app_handle, local_addr, shutdown, _db, _temp) =
         setup_test_app_with_auth(AuthMode::JwtOnly, keys, hashmap! {}).await?;
@@ -313,7 +313,7 @@ async fn v2_delete_identity_requires_auth_when_enforced() -> anyhow::Result<()> 
     init_tracing_subscriber();
 
     let (_, public_pem) = generate_es256_keypair();
-    let keys = hashmap! { "test_key".to_string() => public_pem };
+    let keys = hashmap! { "test_key".to_string() => vec![AuthorizedKey { pem: public_pem, expires_at: None }] };
 
     let (_app, app_handle, local_addr, shutdown, _db, _temp) =
         setup_test_app_with_auth(AuthMode::JwtOnly, keys, hashmap! {}).await?;
@@ -341,7 +341,7 @@ async fn inclusion_proof_no_auth_required() -> anyhow::Result<()> {
     init_tracing_subscriber();
 
     let (_, public_pem) = generate_es256_keypair();
-    let keys = hashmap! { "test_key".to_string() => public_pem };
+    let keys = hashmap! { "test_key".to_string() => vec![AuthorizedKey { pem: public_pem, expires_at: None }] };
 
     let (_app, app_handle, local_addr, shutdown, _db, _temp) =
         setup_test_app_with_auth(AuthMode::JwtOnly, keys, hashmap! {}).await?;
@@ -372,7 +372,7 @@ async fn wrong_key_rejected() -> anyhow::Result<()> {
     let (wrong_private_pem, _) = generate_es256_keypair();
     let (_, correct_public_pem) = generate_es256_keypair();
 
-    let keys = hashmap! { "test_key".to_string() => correct_public_pem };
+    let keys = hashmap! { "test_key".to_string() => vec![AuthorizedKey { pem: correct_public_pem, expires_at: None }] };
 
     let (_app, app_handle, local_addr, shutdown, _db, _temp) =
         setup_test_app_with_auth(AuthMode::JwtOnly, keys, hashmap! {}).await?;


### PR DESCRIPTION
- `authorized_keys` type changes from `HashMap<String, String>` to `HashMap<String, Vec<AuthorizedKey>>`, where `AuthorizedKey` carries a PEM string and an optional `expires_at` timestamp
- JWT validation skips keys whose `expires_at` is in the past, enabling zero-downtime key rotation by listing old and new keys side-by-side
- Env var renamed to `SEQ__SERVER__AUTHORIZED_KEYS_JSON` and accepts a JSON map (`{"name":[{"pem":"...","expires_at":"..."}]}`); the old `authorized_keys` TOML key is kept as a serde alias for compatibility
- Custom serde deserializer handles both TOML sequences and JSON-encoded strings from env vars, including the full inline-map syntax

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/Recni/rust-app-template/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
